### PR TITLE
dont-run-example-deployments-on-renovates-pr

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,3 +21,4 @@ jobs:
     with:
       environment: examples
       tf_dir: ${{ matrix.directory }}
+      tf_workspace: ${{ github.ref_name }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -17,7 +17,7 @@ jobs:
           - examples/lacework
           - examples/complete
 
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml@v0.16.0
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml@v0.18.0
     with:
       environment: examples
       tf_dir: ${{ matrix.directory }}

--- a/.github/workflows/examples-complete.yaml
+++ b/.github/workflows/examples-complete.yaml
@@ -10,6 +10,9 @@ on:
       - synchronize
       - reopened
       - closed
+    branches-ignore:    
+      - 'renovate_**'
+
 
 permissions:
   id-token: write

--- a/.github/workflows/examples-complete.yaml
+++ b/.github/workflows/examples-complete.yaml
@@ -10,8 +10,8 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:    
-      - 'renovate_**'
+    branches-ignore:
+      - 'renovate_*'
 
 
 permissions:

--- a/.github/workflows/examples-lacework.yaml
+++ b/.github/workflows/examples-lacework.yaml
@@ -10,6 +10,8 @@ on:
       - synchronize
       - reopened
       - closed
+    branches-ignore:    
+      - 'renovate_**'
 
 permissions:
   id-token: write

--- a/.github/workflows/examples-lacework.yaml
+++ b/.github/workflows/examples-lacework.yaml
@@ -10,8 +10,8 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:    
-      - 'renovate_**'
+    branches-ignore:
+      - 'renovate_*'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Since it takes up to 30min, it can fail and we don't know when we would check the cluster status it's not worth tu run all examples one very renovate PR. One idea could be to only run a specific test before deciding to merge the renovates PR

Additionally I add the `tf_workspace: ${{ github.ref_name }}` to the cleanup workflow to set the workspace=name of the selected branch. This will fail until https://github.com/tx-pts-dai/github-workflows/pull/50 is merged and relased

This PR will solve https://github.com/tx-pts-dai/terraform-aws-kubernetes-platform/issues/34