### PR TITLE
fix: remove example workflow triggers

### DIFF
--- a/.github/workflows/examples-complete.yaml
+++ b/.github/workflows/examples-complete.yaml
@@ -3,16 +3,14 @@ name: Deploy Module Examples - Complete
 on:
   pull_request:
     paths:
-      - '.github/workflows/examples-complete.yaml'
-      - 'examples/complete/**'
+      - examples/complete/**
     types:
       - opened
       - synchronize
       - reopened
       - closed
     branches-ignore:
-      - 'renovate_*'
-
+      - renovate*
 
 permissions:
   id-token: write

--- a/.github/workflows/examples-lacework.yaml
+++ b/.github/workflows/examples-lacework.yaml
@@ -3,15 +3,14 @@ name: Deploy Module Examples - Lacework
 on:
   pull_request:
     paths:
-      - '.github/workflows/examples-lacework.yaml'
-      - 'examples/lacework/**'
+      - examples/lacework/**
     types:
       - opened
       - synchronize
       - reopened
       - closed
     branches-ignore:
-      - 'renovate_*'
+      - renovate*
 
 permissions:
   id-token: write


### PR DESCRIPTION
So that we dont deploy examples when there is a shared workflow version update
