### PR TITLE
Fum 3224 dd k8s secrets

### DIFF
--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -14,10 +14,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    datadog = {
-      source  = "DataDog/datadog"
-      version = "~> 3.39"
-    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.27"
@@ -35,17 +31,6 @@ terraform {
 
 provider "aws" {
   region = local.region
-}
-
-data "aws_secretsmanager_secret_version" "datadog" {
-  secret_id = "dai-datadog/tamedia/keys"
-}
-
-provider "datadog" {
-  api_url  = "https://api.${local.datadog_site}/"
-  api_key  = jsondecode(data.aws_secretsmanager_secret_version.datadog.secret_string)["api_key"]
-  app_key  = jsondecode(data.aws_secretsmanager_secret_version.datadog.secret_string)["app_key"]
-  validate = true
 }
 
 provider "kubernetes" {
@@ -84,8 +69,7 @@ provider "kubectl" {
 }
 
 locals {
-  region       = "eu-central-1"
-  datadog_site = "datadoghq.eu"
+  region = "eu-central-1"
 }
 
 module "k8s_platform" {
@@ -125,7 +109,7 @@ module "datadog" {
 
   cluster_name = module.k8s_platform.eks.cluster_name
 
-  datadog_secret = "dai-datadog/tamedia/keys"
+  datadog_secret = "dai/datadog/tamedia/keys"
 
   depends_on = [module.k8s_platform]
 }

--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -125,7 +125,5 @@ module "datadog" {
 
   cluster_name = module.k8s_platform.eks.cluster_name
 
-  datadog_secret = "dai-datadog/tamedia/keys"
-
   depends_on = [module.k8s_platform]
 }

--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -125,5 +125,7 @@ module "datadog" {
 
   cluster_name = module.k8s_platform.eks.cluster_name
 
+  datadog_secret = "dai-datadog/tamedia/keys"
+
   depends_on = [module.k8s_platform]
 }

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -28,7 +28,6 @@ module "datadog" {
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.0 |
 
 ## Modules
 
@@ -41,7 +40,7 @@ module "datadog" {
 | Name | Type |
 |------|------|
 | [helm_release.datadog_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_manifest.external_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [helm_release.datadog_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 
 ## Inputs
 

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -19,9 +19,7 @@ module "datadog" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | ~> 3.39 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 
 ## Providers
 

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -51,6 +51,7 @@ module "datadog" {
 | <a name="input_datadog"></a> [datadog](#input\_datadog) | Object of Datadog configurations | <pre>object({<br>    agent_api_key_name            = optional(string) # by default it uses the cluster name<br>    agent_app_key_name            = optional(string) # by default it uses the cluster name<br>    operator_chart_version        = optional(string)<br>    custom_resource_chart_version = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_datadog_agent_helm_values"></a> [datadog\_agent\_helm\_values](#input\_datadog\_agent\_helm\_values) | List of Datadog Agent custom resource values. https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_datadog_operator_helm_values"></a> [datadog\_operator\_helm\_values](#input\_datadog\_operator\_helm\_values) | List of Datadog Operator values | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "resources.requests.cpu",<br>    "value": "10m"<br>  },<br>  {<br>    "name": "resources.requests.memory",<br>    "value": "50Mi"<br>  }<br>]</pre> | no |
+| <a name="input_datadog_secret"></a> [datadog\_secret](#input\_datadog\_secret) | Name of the datadog secret in Secrets Manager | `string` | `"dai-datadog/tamedia/keys"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace for Datadog resources | `string` | `"monitoring"` | no |
 
 ## Outputs

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -50,7 +50,7 @@ module "datadog" {
 | <a name="input_datadog"></a> [datadog](#input\_datadog) | Object of Datadog configurations | <pre>object({<br>    agent_api_key_name            = optional(string) # by default it uses the cluster name<br>    agent_app_key_name            = optional(string) # by default it uses the cluster name<br>    operator_chart_version        = optional(string)<br>    custom_resource_chart_version = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_datadog_agent_helm_values"></a> [datadog\_agent\_helm\_values](#input\_datadog\_agent\_helm\_values) | List of Datadog Agent custom resource values. https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | <a name="input_datadog_operator_helm_values"></a> [datadog\_operator\_helm\_values](#input\_datadog\_operator\_helm\_values) | List of Datadog Operator values | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "resources.requests.cpu",<br>    "value": "10m"<br>  },<br>  {<br>    "name": "resources.requests.memory",<br>    "value": "50Mi"<br>  }<br>]</pre> | no |
-| <a name="input_datadog_secret"></a> [datadog\_secret](#input\_datadog\_secret) | Name of the datadog secret in Secrets Manager | `string` | `"dai-datadog/tamedia/keys"` | no |
+| <a name="input_datadog_secret"></a> [datadog\_secret](#input\_datadog\_secret) | Name of the datadog secret in Secrets Manager | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace for Datadog resources | `string` | `"monitoring"` | no |
 
 ## Outputs

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -27,7 +27,6 @@ module "datadog" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | ~> 3.39 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.0 |
 
@@ -41,10 +40,8 @@ module "datadog" {
 
 | Name | Type |
 |------|------|
-| [datadog_api_key.datadog_agent](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/api_key) | resource |
-| [datadog_application_key.datadog_agent](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/application_key) | resource |
 | [helm_release.datadog_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_secret.datadog_keys](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_manifest.external_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 
 ## Inputs
 

--- a/modules/datadog/main.tf
+++ b/modules/datadog/main.tf
@@ -23,14 +23,14 @@ resource "kubernetes_manifest" "external_secret" {
         {
           secretKey = "api-key"
           remoteRef = {
-            key      = "dai-datadog/tamedia/keys"
+            key      = var.datadog_secret
             property = "api_key"
           }
         },
         {
           secretKey = "app-key"
           remoteRef = {
-            key      = "dai-datadog/tamedia/keys"
+            key      = var.datadog_secret
             property = "app_key"
           }
         }

--- a/modules/datadog/variables.tf
+++ b/modules/datadog/variables.tf
@@ -50,5 +50,4 @@ variable "datadog_operator_helm_values" {
 variable "datadog_secret" {
   description = "Name of the datadog secret in Secrets Manager"
   type        = string
-  default     = "dai-datadog/tamedia/keys"
 }

--- a/modules/datadog/variables.tf
+++ b/modules/datadog/variables.tf
@@ -46,3 +46,9 @@ variable "datadog_operator_helm_values" {
     },
   ]
 }
+
+variable "datadog_secret" {
+  description = "Name of the datadog secret in Secrets Manager"
+  type        = string
+  default     = "dai-datadog/tamedia/keys"
+}

--- a/modules/datadog/versions.tf
+++ b/modules/datadog/versions.tf
@@ -5,14 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0.0"
-    }
-    datadog = {
-      source  = "DataDog/datadog"
-      version = "~> 3.39"
-    }
     helm = {
       source  = "hashicorp/helm"
       version = "~> 2.6"


### PR DESCRIPTION
### Changes
- replacing kubernetes secret creation by external secret
- adding new variable for DataDog secret name
The expected WF:
- The DD secret is already available in Secrets manager, created through https://github.com/tx-pts-dai/datadog-settings/blob/main/account-specific/terraform/keys.tf
- The secret name is passed to the module (default is the name we already use in the previous step).
- The external secret is created through the external secret operator and secret store.