### PR TITLE
fix: aligning secret's keys

### DIFF
--- a/modules/datadog/main.tf
+++ b/modules/datadog/main.tf
@@ -51,11 +51,11 @@ resource "helm_release" "datadog_secrets" {
       - secretKey: api-key
         remoteRef:
           key: ${var.datadog_secret}
-          property: api_key
+          property: DD_API_KEY
       - secretKey: app-key
         remoteRef:
           key: ${var.datadog_secret}
-          property: app_key
+          property: DD_APP_KEY
   YAML
   ]
   depends_on = [module.datadog_operator]
@@ -86,11 +86,11 @@ resource "helm_release" "datadog_secrets_fargate" {
       - secretKey: api-key
         remoteRef:
           key: ${var.datadog_secret}
-          property: api_key
+          property: DD_API_KEY
       - secretKey: app-key
         remoteRef:
           key: ${var.datadog_secret}
-          property: app_key
+          property: DD_APP_KEY
   YAML
   ]
   depends_on = [module.datadog_operator]


### PR DESCRIPTION
I've aligned the DD sandbox secrets keys in order to have the same across all environments.