### PR TITLE
feat: reverse the order of the ssm stacks output so that the latest i…

### DIFF
--- a/modules/ssm/README.md
+++ b/modules/ssm/README.md
@@ -161,10 +161,10 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_filtered_parameters"></a> [filtered\_parameters](#output\_filtered\_parameters) | List of parameters filtered by stack name prefix |
-| <a name="output_latest_stack_parameters"></a> [latest\_stack\_parameters](#output\_latest\_stack\_parameters) | Latest stack parameters |
-| <a name="output_lookup"></a> [lookup](#output\_lookup) | Map of looked up parameters |
-| <a name="output_parameters"></a> [parameters](#output\_parameters) | Parameters defined in SSM |
-| <a name="output_stacks"></a> [stacks](#output\_stacks) | List of stacks defined in SSM |
+| <a name="output_latest_stack_parameters"></a> [latest\_stack\_parameters](#output\_latest\_stack\_parameters) | Latest created stack parameters |
+| <a name="output_lookup"></a> [lookup](#output\_lookup) | Map of parameters from filtered parameters containing only keys defined in lookup |
+| <a name="output_parameters"></a> [parameters](#output\_parameters) | All parameters defined in SSM |
+| <a name="output_stacks"></a> [stacks](#output\_stacks) | List of stacks defined in SSM ordered by creation date (latest first) |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributions

--- a/modules/ssm/lookup.tf
+++ b/modules/ssm/lookup.tf
@@ -31,11 +31,10 @@ locals {
   }
 
   # Identify the latest stack - since stacks are reversed, the latest stack is the first element
-  # latest_stack = length(local.stacks) > 0 ? element(local.stacks, length(local.stacks) - 1) : null
-  latest_stack = local.stacks[0]
+  latest_stack = try(local.stacks[0], null)
   # Extract parameters for the latest stack if latest_stack is not null
   latest_stack_parameters = local.latest_stack != null ? {
-    for key, value in local.parameters : key => value
+    for key, value in local.parameters : element(split("/", key), length(split("/", key)) - 1) => value
     if strcontains(key, local.latest_stack)
   } : {}
 }

--- a/modules/ssm/lookup.tf
+++ b/modules/ssm/lookup.tf
@@ -16,8 +16,8 @@ locals {
   }
 
   # Extract stack names filtered by stack name prefix
-  stacks = distinct([for key, _ in local.parameters : element(split("/", key), length(split("/", key)) - 2)
-  if var.stack_name_prefix == "" || startswith(element(split("/", key), length(split("/", key)) - 2), var.stack_name_prefix)])
+  stacks = reverse(distinct([for key, _ in local.parameters : element(split("/", key), length(split("/", key)) - 2)
+  if var.stack_name_prefix == "" || startswith(element(split("/", key), length(split("/", key)) - 2), var.stack_name_prefix)]))
 
   # Create a lookup map for stack-specific parameters
   lookup = {
@@ -30,8 +30,9 @@ locals {
     }
   }
 
-  # Identify the latest stack
-  latest_stack = length(local.stacks) > 0 ? element(local.stacks, length(local.stacks) - 1) : null
+  # Identify the latest stack - since stacks are reversed, the latest stack is the first element
+  # latest_stack = length(local.stacks) > 0 ? element(local.stacks, length(local.stacks) - 1) : null
+  latest_stack = local.stacks[0]
   # Extract parameters for the latest stack if latest_stack is not null
   latest_stack_parameters = local.latest_stack != null ? {
     for key, value in local.parameters : key => value

--- a/modules/ssm/outputs.tf
+++ b/modules/ssm/outputs.tf
@@ -1,10 +1,10 @@
 output "stacks" {
-  description = "List of stacks defined in SSM"
+  description = "List of stacks defined in SSM ordered by creation date (latest first)"
   value       = local.stacks
 }
 
 output "lookup" {
-  description = "Map of looked up parameters"
+  description = "Map of parameters from filtered parameters containing only keys defined in lookup"
   value       = local.lookup
 }
 
@@ -14,11 +14,11 @@ output "filtered_parameters" {
 }
 
 output "latest_stack_parameters" {
-  description = "Latest stack parameters"
+  description = "Latest created stack parameters"
   value       = local.latest_stack_parameters
 }
 
 output "parameters" {
-  description = "Parameters defined in SSM"
+  description = "All parameters defined in SSM"
   value       = local.parameters
 }

--- a/modules/ssm/tests/main.tf
+++ b/modules/ssm/tests/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket               = "tf-state-911453050078"
+    key                  = "ssm/tests/terraform.tfstate"
+    workspace_key_prefix = "terraform-aws-kubernetes-platform"
+    dynamodb_table       = "terraform-lock"
+    region               = "eu-central-1"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  region = "eu-central-1"
+}
+
+provider "aws" {
+  region = local.region
+}
+
+module "ssm_lookup_latest_stack_parameters" {
+  source = "./.."
+
+  base_prefix       = "infrastructure"
+  stack_type        = "platform"
+  stack_name_prefix = ""
+}

--- a/modules/ssm/tests/outputs.tf
+++ b/modules/ssm/tests/outputs.tf
@@ -1,0 +1,9 @@
+output "stacks" {
+  description = "List of stacks"
+  value       = module.ssm_lookup_latest_stack_parameters.stacks
+
+}
+output "latest_stack_parameters" {
+  description = "Latest stack parameters"
+  value       = module.ssm_lookup_latest_stack_parameters.latest_stack_parameters
+}


### PR DESCRIPTION
…s first

## Description
<!--- Describe your changes in detail -->

Reverse stacks list order to put the latest as the first

Make latest_stack_parameters more usable by removing the prefix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
