### PR TITLE
fix: error-ebs-csi-driver

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -13,7 +13,9 @@ module "ebs_csi_driver_irsa" {
 
   role_name = "ebs-csi-driver-${local.id}"
 
-  attach_ebs_csi_policy = true
+  role_policy_arns = {
+    ebs_csi_driver = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  }
 
   oidc_providers = {
     main = {


### PR DESCRIPTION
https://app.datadoghq.eu/logs?query=status%3Aerror%20volumesnapshotcontents.snapshot.storage.k8s.io&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1734857037113&to_ts=1734943437113&live=false

## Description
Use aws managed policy for ebs csi driver as recommended
