### PR TITLE
Adjust fluent-op request

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.97.0
     hooks:
       - id: terraform_fmt
         args:
@@ -35,7 +35,7 @@ repos:
       - id: trailing-whitespace
       - id: no-commit-to-branch
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.112.0
+    rev: 39.113.0
     hooks:
       - id: renovate-config-validator
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="module_amp"></a> [amp](#module\_amp) | terraform-aws-modules/managed-service-prometheus/aws | 3.0.0 |
 | <a name="module_cluster_secret_store"></a> [cluster\_secret\_store](#module\_cluster\_secret\_store) | ./modules/addon | n/a |
 | <a name="module_downscaler"></a> [downscaler](#module\_downscaler) | tx-pts-dai/downscaler/kubernetes | 0.3.1 |
-| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.1 |
+| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.2 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.31.6 |
 | <a name="module_fluent_operator"></a> [fluent\_operator](#module\_fluent\_operator) | ./modules/addon | n/a |
 | <a name="module_grafana"></a> [grafana](#module\_grafana) | ./modules/addon | n/a |
@@ -167,13 +167,13 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
 | <a name="module_okta_secrets"></a> [okta\_secrets](#module\_okta\_secrets) | ./modules/addon | n/a |
 | <a name="module_pagerduty_secrets"></a> [pagerduty\_secrets](#module\_pagerduty\_secrets) | ./modules/addon | n/a |
-| <a name="module_prometheus_irsa"></a> [prometheus\_irsa](#module\_prometheus\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.1 |
+| <a name="module_prometheus_irsa"></a> [prometheus\_irsa](#module\_prometheus\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.2 |
 | <a name="module_prometheus_operator_crds"></a> [prometheus\_operator\_crds](#module\_prometheus\_operator\_crds) | ./modules/addon | n/a |
 | <a name="module_prometheus_stack"></a> [prometheus\_stack](#module\_prometheus\_stack) | ./modules/addon | n/a |
 | <a name="module_reloader"></a> [reloader](#module\_reloader) | ./modules/addon | n/a |
 | <a name="module_slack_secrets"></a> [slack\_secrets](#module\_slack\_secrets) | ./modules/addon | n/a |
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | ./modules/ssm | n/a |
-| <a name="module_vpc_cni_irsa"></a> [vpc\_cni\_irsa](#module\_vpc\_cni\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.1 |
+| <a name="module_vpc_cni_irsa"></a> [vpc\_cni\_irsa](#module\_vpc\_cni\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.52.2 |
 
 ## Resources
 

--- a/files/helm/fluent-operator/common.yaml
+++ b/files/helm/fluent-operator/common.yaml
@@ -1,6 +1,13 @@
 containerRuntime: containerd
 operator:
   priorityClassName: system-cluster-critical
+  resources:
+    limits:
+      cpu: 100m
+      memory: 60Mi
+    requests:
+      cpu: 100m
+      memory: 40Mi
 fluentbit:
   enabled: true
   priorityClassName: system-node-critical

--- a/files/helm/fluent-operator/common.yaml
+++ b/files/helm/fluent-operator/common.yaml
@@ -2,12 +2,12 @@ containerRuntime: containerd
 operator:
   priorityClassName: system-cluster-critical
   resources:
-    limits:
-      cpu:
-      memory:
     requests:
       cpu: 100m
       memory: 100Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi
 fluentbit:
   enabled: true
   priorityClassName: system-node-critical

--- a/files/helm/fluent-operator/common.yaml
+++ b/files/helm/fluent-operator/common.yaml
@@ -2,6 +2,9 @@ containerRuntime: containerd
 operator:
   priorityClassName: system-cluster-critical
   resources:
+    limits:
+      cpu:
+      memory:
     requests:
       cpu: 100m
       memory: 100Mi

--- a/files/helm/fluent-operator/common.yaml
+++ b/files/helm/fluent-operator/common.yaml
@@ -2,12 +2,9 @@ containerRuntime: containerd
 operator:
   priorityClassName: system-cluster-critical
   resources:
-    limits:
-      cpu: 100m
-      memory: 60Mi
     requests:
       cpu: 100m
-      memory: 40Mi
+      memory: 100Mi
 fluentbit:
   enabled: true
   priorityClassName: system-node-critical


### PR DESCRIPTION
Because of alert.
Operator uses 30MiB with max=37 on last 2 days

## Description
Adapt request on what is needed

## Motivation and Context
We got alert that:

[[prod-discovery,production-discovery] Average RAM usage of fluent-operator is significantly higher than its request](https://tx-pts-dai.pagerduty.com/incidents/Q0OJBVGD4OE9YU?utm_campaign=channel&utm_source=slack)

## Breaking Changes
- None
- 
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
