### PR TITLE
fix: downgrade karpenter version for backwards support (v1beta apis)

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -43,7 +43,7 @@ module "karpenter_crds" {
   source = "./modules/addon"
 
   chart            = "karpenter-crd"
-  chart_version    = "1.1.1"
+  chart_version    = "1.0.8"
   repository       = "oci://public.ecr.aws/karpenter"
   description      = "Karpenter CRDs"
   namespace        = local.karpenter.namespace
@@ -55,7 +55,7 @@ module "karpenter_release" {
   source = "./modules/addon"
 
   chart            = "karpenter"
-  chart_version    = "1.1.1"
+  chart_version    = "1.0.8"
   repository       = "oci://public.ecr.aws/karpenter"
   namespace        = local.karpenter.namespace
   create_namespace = true


### PR DESCRIPTION
## Description
v1beta is removed from 1.1.0

## Motivation and Context
caused breaking change

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
