### PR TITLE
fix: karpenter requires more resources

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -71,8 +71,8 @@ module "karpenter_release" {
     controller:
       resources:
         requests:
-          cpu: 0.25
-          memory: "256Mi"
+          cpu: 0.5
+          memory: "512Mi"
     serviceMonitor:
       enabled: ${module.prometheus_operator_crds.create}
     settings:


### PR DESCRIPTION
## Description
Karpenter crash looping due to healthcheck timeout

## Motivation and Context

I can see cpu and memory usage hitting the limits

This is doubling the costs of karpenter in fargate to $37+tax for two replicas. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
