### PR TITLE
ci: run feature branch test module except for when triggered by renovate

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -2,23 +2,23 @@ name: Feature Branch Test
 
 on:
   pull_request:
+    paths:
+      - "*.tf"
+      - "files/helm/**/*.yaml"
+      - "K8S_VERSION"
     types:
+      - opened
+      - synchronize
+      - reopened
       - closed
     branches:
       - main
+
   workflow_dispatch:
-    inputs:
-      tf_dir:
-        description: 'Directory'
-        required: true
-        default: 'tests/main'
-        type: choice
-        options:
-          - tests/main
 
 jobs:
   feature_deploy:
-    if: github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed' && github.triggering_actor != 'renovate[bot]') || github.event_name == 'workflow_dispatch'
     uses: tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml@v2
     with:
       environment: examples


### PR DESCRIPTION
## Description

If we are touching anything tha can potentially change something in the module, a pr should not be able to go through without a full deployment. 

Renovate PRs will not run except if the workflow is retriggered by someone

In the future a deploy button would be helpful

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
