### PR TITLE
fix: karpenter metrics port

### DIFF
--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -100,7 +100,7 @@ module "k8s_platform" {
         {
           "karpenter" : {
             "init_config" : {},
-            "instances" : [{ "openmetrics_endpoint" : "http://%%host%%:8000/metrics" }]
+            "instances" : [{ "openmetrics_endpoint" : "http://%%host%%:8080/metrics" }]
           }
         }
       )


### PR DESCRIPTION


## Description
Default port changed in v1 helm chart

## Motivation and Context
Metrics not shipped to datadog

## Breaking Changes
NA
## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
