### PR TITLE
fix: argocd value error

### DIFF
--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -119,7 +119,7 @@ resource "aws_eks_pod_identity_association" "argocd_server" {
 
 ##################### ArgoCD Spoke ###########################################
 locals {
-  hub_iam_role_arn = coalesce(var.hub_iam_role_arn, aws_iam_role.argocd_controller[0].arn)
+  hub_iam_role_arn = var.enable_spoke ? (var.hub_iam_role_arn != null ? var.hub_iam_role_arn : (var.enable_hub ? aws_iam_role.argocd_controller[0].arn : null)) : null
 }
 
 data "aws_iam_policy_document" "argocd_spoke" {

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -119,7 +119,7 @@ resource "aws_eks_pod_identity_association" "argocd_server" {
 
 ##################### ArgoCD Spoke ###########################################
 locals {
-  hub_iam_role_arn = var.enable_spoke ? (var.hub_iam_role_arn != null ? var.hub_iam_role_arn : (var.enable_hub ? aws_iam_role.argocd_controller[0].arn : null)) : null
+  hub_iam_role_arn = var.create && var.enable_spoke ? (var.hub_iam_role_arn != null ? var.hub_iam_role_arn : (var.enable_hub ? aws_iam_role.argocd_controller[0].arn : null)) : null
 }
 
 data "aws_iam_policy_document" "argocd_spoke" {


### PR DESCRIPTION
## Description
coalesce function returned null if argocd hub or spoke was not enabled causing a general error. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
