### PR TITLE
feat!: karpenter resources helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+
+v2.0.0+1.32.0
+
+Breaking Changes:
+
+- Setting disk size via the karpenter variable is now deprecated. Use the karpenter_resources variable instead.
+
+```
+karpenter = {
+  ...
+  data_volume_size = 80Gi
+  ...
+}
+```
+
+Use the karpenter_resources variable instead.
+
+```
+karpenter = {
+  ...
+  karpenter_resources = {
+    ...
+    ec2NodeClasses:
+      blockDeviceMappings:
+        - deviceName: /dev/xvda
+          ebs:
+            volumeSize: 80Gi
+            volumeType: gp3
+            encrypted: true
+      }
+    }
+  }
+  ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -184,29 +184,29 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | 5.1.1 |
-| <a name="module_addons"></a> [addons](#module\_addons) | aws-ia/eks-blueprints-addons/aws | 1.20.0 |
+| <a name="module_addons"></a> [addons](#module\_addons) | aws-ia/eks-blueprints-addons/aws | 1.21.0 |
 | <a name="module_amp"></a> [amp](#module\_amp) | terraform-aws-modules/managed-service-prometheus/aws | 3.0.0 |
 | <a name="module_argocd"></a> [argocd](#module\_argocd) | ./modules/argocd | n/a |
 | <a name="module_cluster_secret_store"></a> [cluster\_secret\_store](#module\_cluster\_secret\_store) | ./modules/addon | n/a |
 | <a name="module_downscaler"></a> [downscaler](#module\_downscaler) | tx-pts-dai/downscaler/kubernetes | 0.3.1 |
-| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.34.0 |
+| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.1 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.35.0 |
 | <a name="module_fluent_operator"></a> [fluent\_operator](#module\_fluent\_operator) | ./modules/addon | n/a |
 | <a name="module_grafana"></a> [grafana](#module\_grafana) | ./modules/addon | n/a |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 20.34.0 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 20.35.0 |
 | <a name="module_karpenter_crds"></a> [karpenter\_crds](#module\_karpenter\_crds) | ./modules/addon | n/a |
 | <a name="module_karpenter_release"></a> [karpenter\_release](#module\_karpenter\_release) | ./modules/addon | n/a |
 | <a name="module_karpenter_security_group"></a> [karpenter\_security\_group](#module\_karpenter\_security\_group) | ./modules/security-group | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
 | <a name="module_okta_secrets"></a> [okta\_secrets](#module\_okta\_secrets) | ./modules/addon | n/a |
 | <a name="module_pagerduty_secrets"></a> [pagerduty\_secrets](#module\_pagerduty\_secrets) | ./modules/addon | n/a |
-| <a name="module_prometheus_irsa"></a> [prometheus\_irsa](#module\_prometheus\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.0 |
+| <a name="module_prometheus_irsa"></a> [prometheus\_irsa](#module\_prometheus\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.1 |
 | <a name="module_prometheus_operator_crds"></a> [prometheus\_operator\_crds](#module\_prometheus\_operator\_crds) | ./modules/addon | n/a |
 | <a name="module_prometheus_stack"></a> [prometheus\_stack](#module\_prometheus\_stack) | ./modules/addon | n/a |
 | <a name="module_reloader"></a> [reloader](#module\_reloader) | ./modules/addon | n/a |
 | <a name="module_slack_secrets"></a> [slack\_secrets](#module\_slack\_secrets) | ./modules/addon | n/a |
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | ./modules/ssm | n/a |
-| <a name="module_vpc_cni_irsa"></a> [vpc\_cni\_irsa](#module\_vpc\_cni\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.0 |
+| <a name="module_vpc_cni_irsa"></a> [vpc\_cni\_irsa](#module\_vpc\_cni\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.54.1 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.42.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.27 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
 
@@ -217,6 +219,7 @@ as described in the `.pre-commit-config.yaml` file
 | [aws_route_table_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_security_group_rule.eks_control_plane_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [kubectl_manifest.karpenter_resources](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [kubernetes_annotations.monitoring](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [time_sleep.wait_on_destroy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_static.timestamp_id](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
@@ -227,6 +230,7 @@ as described in the `.pre-commit-config.yaml` file
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.base_domain_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_route_tables.private_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
+| [helm_template.karpenter_resources](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template) | data source |
 
 ## Inputs
 

--- a/docs/examples/snippets/karpenter.md
+++ b/docs/examples/snippets/karpenter.md
@@ -1,0 +1,127 @@
+# Karpenter
+
+By default the Kubernetes as a Service (KaaS) module will deploy a Karpenter controller and the custom resources for creating nodes. These resources are [NodePool](https://karpenter.sh/docs/concepts/nodepools/) and [Ec2NodeClass](https://karpenter.sh/docs/concepts/nodeclasses/). You can think of these as NodeClass defines the ec2 launch template and NodePool defines the node group. The Karpenter controller will then create the nodes based on the node class and node pool.
+
+## Configuration
+
+To customise the Karpenter configuration, you need to define the necessary variables in the `kaas` module. The following example shows how to do this:
+
+```hcl
+module "k8s_platform" {
+  source = "../../"
+
+  name = "ex-complete"
+
+  ...redacted for brevity...
+
+  # Karpenter general configuration variable
+  karpenter = {
+    values = [
+      # Add your custom values here
+      # These will be treated like how helm treat values inputs. eg. helm install -f values.yaml -f values2.yaml
+      replicas: 2
+    ]
+    # Karpenter Helm chart sets
+    set = [
+      {
+        name  = "replicas"
+        value = 1
+      }
+    ]
+
+
+## Karpenter Custom Resources
+
+The Karpenter custom resources are defined in the `karpenter_resources` variable. This variable is a map of values that will be passed to the [Karpenter resources Helm chart](https://github.com/DND-IT/helm-charts/tree/main/charts/karpenter-resources#karpenter-resources). The following example shows how to define the Karpenter custom resources:
+
+```hcl
+module "k8s_platform" {
+  source = "../../"
+
+  name = "ex-complete"
+
+  ...redacted for brevity...
+
+  # Karpenter general configuration variable
+  karpenter = {
+    # Karpenter custom resources overrides
+    # Direct inline overrides to the Karpenter custom resources
+    karpenter_resources = {
+      values = [
+        file("${path.module}/karpenter-values.yaml"), # Set the values file
+        <<-EOT # Inline YAML
+        nodePools:
+          default:
+            requirements:
+              - key: karpenter.k8s.aws/instance-category
+                operator: In
+                values: ["t"]
+        EOT
+      ]
+      set = [ # Set the values directly
+        {
+          name  = "nodePools.default.requirements[0].key"
+          value = "karpenter.k8s.aws/instance-category"
+        },
+        {
+          name  = "nodePools.default.requirements[0].operator"
+          value = "In"
+        },
+        {
+          name  = "nodePools.default.requirements[0].values"
+          value = "[\"t\"]"
+        }
+      ]
+    }
+  }
+}
+```
+
+```hcl
+data "helm_template" "karpenter_custom_resources" {
+  name       = "karpenter-resources"
+  chart      = "karpenter-resources"
+  version    = "0.3.1"
+  repository = "https://dnd-it.github.io/helm-charts"
+  namespace  = local.karpenter.namespace
+
+  values = [
+    <<-EOT
+    global:
+      role: ${module.k8s_platform.karpenter.node_iam_role_name}
+      eksDiscovery:
+        enabled: true
+        clusterName: ${module.k8s_platform.eks.cluster_name}
+
+    nodePools:
+      custom:
+        requirements:
+          - key: karpenter.k8s.aws/instance-category
+            operator: In
+            values: ["t"]
+        labels:
+          my-custom-nodepool: "true"
+        taints:
+          - key: "karpenter.sh/capacity-type"
+            value: "spot"
+            effect: "NoSchedule"
+        limits:
+          resources:
+            cpu: 100
+            memory: 10Gi
+        providerRef:
+          name: custom
+
+    ec2NodeClasses:
+      custom:
+        amiFamily: al2023
+        amiSelectorTerms:
+          - alias: al2023@v20240807
+        tags:
+          Name: "custom-node-class"
+        kubelet:
+          maxPods: 10
+    EOT
+  ]
+}
+```

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -141,9 +141,7 @@ data "helm_template" "karpenter_resources" {
 }
 
 resource "kubectl_manifest" "karpenter_resources" {
-  for_each = data.helm_template.karpenter_resources.manifests
-
-  yaml_body = each.value
+  yaml_body = data.helm_template.karpenter_resources.manifest
 
   depends_on = [module.karpenter_release]
 }

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -13,9 +13,6 @@ locals {
     namespace = "kube-system"
     # TODO: move to helm value inputs
     pod_annotations = try(var.karpenter.pod_annotations, {})
-
-    root_volume_size = try(var.karpenter.root_volume_size, "4Gi")
-    data_volume_size = try(var.karpenter.data_volume_size, "20Gi")
   }
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -64,7 +61,7 @@ module "karpenter_release" {
   skip_crds        = true
   wait             = true
 
-  values = [
+  values = concat([
     <<-EOT
     logLevel: info
     dnsPolicy: Default
@@ -88,7 +85,7 @@ module "karpenter_release" {
       annotations:
         eks.amazonaws.com/role-arn: ${module.karpenter.iam_role_arn}
     EOT
-  ]
+  ], try(var.karpenter.values, []))
 
   set      = try(var.karpenter.set, [])
   set_list = try(var.karpenter.set_list, [])

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -141,7 +141,9 @@ data "helm_template" "karpenter_resources" {
 }
 
 resource "kubectl_manifest" "karpenter_resources" {
-  yaml_body = data.helm_template.karpenter_resources.manifest
+  for_each = data.helm_template.karpenter_resources.manifests
+
+  yaml_body = each.value
 
   depends_on = [module.karpenter_release]
 }

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -26,6 +26,8 @@ nav:
       - examples/simple.md
       - examples/lacework.md
       - examples/datadog.md
+      - Snippets:
+          - examples/snippets/karpenter.md
   - FAQ: faq.md
 
 theme:
@@ -78,7 +80,6 @@ plugins:
   - search:
       lang:
         - en
-  # - awesome-pages
   - tags
 
 markdown_extensions:

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -287,7 +287,7 @@ module "prometheus_stack" {
         annotations:
           alb.ingress.kubernetes.io/scheme: internet-facing
           alb.ingress.kubernetes.io/target-type: ip
-          alb.ingress.kubernetes.io/group.name: ${local.stack_name}
+          alb.ingress.kubernetes.io/group.name: default
           alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
           alb.ingress.kubernetes.io/ssl-redirect: '443'
           alb.ingress.kubernetes.io/healthcheck-path: /-/healthy
@@ -318,7 +318,7 @@ module "prometheus_stack" {
         annotations:
           alb.ingress.kubernetes.io/scheme: internet-facing
           alb.ingress.kubernetes.io/target-type: ip
-          alb.ingress.kubernetes.io/group.name: ${local.stack_name}
+          alb.ingress.kubernetes.io/group.name: default
           alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
           alb.ingress.kubernetes.io/ssl-redirect: '443'
           alb.ingress.kubernetes.io/healthcheck-path: /-/healthy
@@ -458,7 +458,7 @@ module "grafana" {
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
-        alb.ingress.kubernetes.io/group.name: ${local.stack_name}
+        alb.ingress.kubernetes.io/group.name: default
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
         alb.ingress.kubernetes.io/ssl-redirect: '443'
         alb.ingress.kubernetes.io/healthcheck-path: /healthz

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -115,6 +115,18 @@ module "k8s_platform" {
         value = 1
       }
     ]
+    karpenter_resources = {
+      values = [
+        <<-EOT
+        nodePools:
+          default:
+            requirements:
+              - key: karpenter.k8s.aws/instance-category
+                operator: In
+                values: ["t"]
+        EOT
+      ]
+    }
   }
 
   metrics_server = {

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -190,12 +190,13 @@ module "k8s_platform" {
 
   enable_amp = false
 
-  enable_argocd = true
+  enable_argocd = false
 
   argocd = {
     enable_hub   = true
     enable_spoke = true
 
+    hub_iam_role_name     = "argocd-controller-${module.k8s_platform.cluster_id}"
     cluster_secret_suffix = "example"
     cluster_secret_labels = {
       team        = "example"

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -196,7 +196,7 @@ module "k8s_platform" {
     enable_hub   = true
     enable_spoke = true
 
-    hub_iam_role_name     = "argocd-controller-${module.k8s_platform.cluster_id}"
+    hub_iam_role_name     = "argocd-controller-tests-main"
     cluster_secret_suffix = "example"
     cluster_secret_labels = {
       team        = "example"

--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -115,16 +115,6 @@ module "k8s_platform" {
         value = 1
       }
     ]
-    additional_helm_releases = {
-      karpenter_node_pool = {
-        set_list = [
-          {
-            name  = "spec.template.spec.requirements[0].values"
-            value = ["t"]
-          }
-        ]
-      }
-    }
   }
 
   metrics_server = {


### PR DESCRIPTION
## Description
Deploy karpenter custom resources with a helmchart

How to overwrite / add node pool / class
```
karpenter = {
  karpenter_resources = {
    values = [
      <<-EOT
      nodePools:
        custom:
          enabled: true
          labels:
            environment: test
            team: basic
          annotations:
            environment: test
            team: basic
          taints:
            - key: "custom"
              value: "true"
              effect: "NoSchedule"
          nodeClassRef:
            name: default
            group: karpenter.k8s.aws
            kind: EC2NodeClass
          expireAfter: "666h"
          disruption:
            consolidationPolicy: "WhenEmptyOrUnderutilized"
            consolidateAfter: "5m"
          limits:
            cpu: 100
            memory: 400Gi
          weight: 100
          requirements:
            - key: "karpenter.k8s.aws/instance-category"
              operator: In
              values: ["c", "m"]
            - key: "karpenter.k8s.aws/instance-cpu"
              operator: In
              values: ["8", "16", "32"]
            - key: "karpenter.k8s.aws/instance-hypervisor"
              operator: In
              values: ["nitro"]
            - key: "karpenter.k8s.aws/instance-generation"
              operator: Gt
              values: ["2"]
            - key: "karpenter.sh/capacity-type"
              operator: In
              values: ["spot", "on-demand"]
      EOT
    ]
    set = [
      {
        name = "nodePools.default.enabled"
        value = "false"
      }
    ]
  }
}
  
```

Example Overwrite

```
  karpenter = {
    set = [
      {
        name  = "replicas"
        value = 1
      }
    ]
    karpenter_resources = {
      values = [
        <<-EOT
        nodePools:
          default:
            requirements:
              - key: custom
                operator: In
                values: ["t"]
        EOT
      ]
    }
  }
```

Terraform Diff
```
  # module.k8s_platform.kubectl_manifest.karpenter_resources["templates/nodepool.yaml"] will be updated in-place
  ~ resource "kubectl_manifest" "karpenter_resources" {
        id                      = "/apis/karpenter.sh/v1/nodepools/default"
        name                    = "default"
      ~ yaml_body               = (sensitive value)
      ~ yaml_body_parsed        = <<-EOT
            apiVersion: karpenter.sh/v1
            kind: NodePool
            metadata:
              labels:
                app.kubernetes.io/managed-by: Helm
                app.kubernetes.io/version: 1.3.3
                helm.sh/chart: karpenter-resources-0.3.1s
              name: default
            spec:
              disruption:
                consolidateAfter: 5m
                consolidationPolicy: WhenEmptyOrUnderutilized
              limits:
                cpu: 1000
                memory: 4000Gi
              template:
                metadata: null
                spec:
                  expireAfter: 720h
                  nodeClassRef:
                    group: karpenter.k8s.aws
                    kind: EC2NodeClass
                    name: default
                  requirements:
          -       - key: karpenter.k8s.aws/instance-category
          +       - key: custom
                    operator: In
                    values:
          -         - c
          -         - m
          -         - r
                    - t
          -       - key: karpenter.k8s.aws/instance-cpu
          -         operator: In
          -         values:
          -         - "4"
          -         - "8"
          -         - "16"
          -         - "32"
          -       - key: karpenter.k8s.aws/instance-hypervisor
          -         operator: In
          -         values:
          -         - nitro
          -       - key: karpenter.k8s.aws/instance-memory
          -         operator: Gt
          -         values:
          -         - "2048"
          -       - key: karpenter.sh/capacity-type
          -         operator: In
          -         values:
          -         - spot
          -         - on-demand
          -       - key: karpenter.k8s.aws/instance-generation
          -         operator: Gt
          -         values:
          -         - "2"
        EOT
 }
```
## Motivation and Context
To be able to easily configure and control what is deployed in the cluster, use helm charts as we can control defaults outside of this repo. 

This is what helm does well, packaging.

I used the data source helm_template so we can see the actual changes happening between applies

## Breaking Changes
- Setting disk size via the karpenter variable is now deprecated. Use the karpenter_resources variable instead.

Old:

```
karpenter = {
  ...
  data_volume_size = 80Gi
  ...
}
```

New:

```
karpenter = {
  ...
  karpenter_resources = {
    ...
    ec2NodeClasses:
      default:
          blockDeviceMappings:
            - deviceName: /dev/xvda
              ebs:
                volumeSize: 80Gi
                volumeType: gp3
                encrypted: true
      }
    }
  }
  ...
}
```


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
