### PR TITLE
fix: add support for multiple hub roles in a spoke

### DIFF
--- a/modules/argocd/README.md
+++ b/modules/argocd/README.md
@@ -87,7 +87,8 @@ module "spoke" {
 | <a name="input_enable_spoke"></a> [enable\_spoke](#input\_enable\_spoke) | Enable ArgoCD Spoke | `bool` | `false` | no |
 | <a name="input_helm_set"></a> [helm\_set](#input\_helm\_set) | Set values to pass to the Helm chart | `list(string)` | `[]` | no |
 | <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_hub_iam_role_arn"></a> [hub\_iam\_role\_arn](#input\_hub\_iam\_role\_arn) | IAM Role ARN for ArgoCD Hub. This is required for spoke clusters | `string` | `null` | no |
+| <a name="input_hub_iam_role_arn"></a> [hub\_iam\_role\_arn](#input\_hub\_iam\_role\_arn) | (Deprecated, use hub\_iam\_role\_arns) IAM Role ARN for ArgoCD Hub. This is required for spoke clusters | `string` | `null` | no |
+| <a name="input_hub_iam_role_arns"></a> [hub\_iam\_role\_arns](#input\_hub\_iam\_role\_arns) | A list of ArgoCD Hub IAM Role ARNs, enabling hubs to access spoke clusters. This is required for spoke clusters. | `list(string)` | `null` | no |
 | <a name="input_hub_iam_role_name"></a> [hub\_iam\_role\_name](#input\_hub\_iam\_role\_name) | IAM Role Name for ArgoCD Hub. This is referenced by the Spoke clusters | `string` | `"argocd-controller"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to deploy ArgoCD | `string` | `"argocd"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/argocd/examples/main.tf
+++ b/modules/argocd/examples/main.tf
@@ -108,4 +108,6 @@ module "spoke" {
   cluster_secret_suffix = "sandbox"
 
   hub_iam_role_arn = module.hub.hub_iam_role_arn
+
+  hub_iam_role_arns = ["arn:aws:iam::123456789012:role/another-role"]
 }

--- a/modules/argocd/variables.tf
+++ b/modules/argocd/variables.tf
@@ -39,8 +39,15 @@ variable "hub_iam_role_name" {
 }
 
 variable "hub_iam_role_arn" {
-  description = "IAM Role ARN for ArgoCD Hub. This is required for spoke clusters"
+  description = "(Deprecated, use hub_iam_role_arns) IAM Role ARN for ArgoCD Hub. This is required for spoke clusters"
   type        = string
+
+  default = null
+}
+
+variable "hub_iam_role_arns" {
+  description = "A list of ArgoCD Hub IAM Role ARNs, enabling hubs to access spoke clusters. This is required for spoke clusters."
+  type        = list(string)
 
   default = null
 }


### PR DESCRIPTION
## Description
Allow more than one hub to have access to a cluster

## Motivation and Context
This allows having the dev / sandbox controllers also access clusters for testing

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
