### PR TITLE
fix: remove addon merge configs and allow direct var input concatenation. 

### DIFF
--- a/tests/main/main.tf
+++ b/tests/main/main.tf
@@ -143,10 +143,10 @@ module "k8s_platform" {
         name  = "replicaCount"
         value = 1
       },
-      {
-        name  = "clusterSecretsPermissions.allowAllSecrets"
-        value = true # enables Okta integration by reading client id and secret from K8s secrets
-      }
+      # {
+      #   name  = "clusterSecretsPermissions.allowAllSecrets"
+      #   value = true # enables Okta integration by reading client id and secret from K8s secrets
+      # }
     ]
   }
 
@@ -194,7 +194,7 @@ module "k8s_platform" {
 
   enable_amp = false
 
-  enable_argocd = true
+  enable_argocd = false
 
   argocd = {
     enable_hub   = false


### PR DESCRIPTION
## Description
Fix issue where nested values cannot be concated causing upstream settings to be overwritten 

## Motivation and Context
flexibility in settings helm inputs

## Breaking Changes
none

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
