### PR TITLE
feat: upgrade datadog helm chart

### DIFF
--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -1,12 +1,12 @@
 terraform {
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.11"
 
   backend "s3" {
     bucket               = "tf-state-911453050078"
     key                  = "examples/datadog.tfstate"
     workspace_key_prefix = "terraform-aws-kubernetes-platform"
     region               = "eu-central-1"
-    dynamodb_table       = "terraform-lock"
+    use_lockfile         = true
   }
 
   required_providers {
@@ -95,18 +95,23 @@ module "k8s_platform" {
   }
 
   karpenter = {
-    pod_annotations = {
-      "ad.datadoghq.com/controller.checks" = jsonencode(
-        {
-          "karpenter" : {
-            "init_config" : {},
-            "instances" : [{ "openmetrics_endpoint" : "http://%%host%%:8080/metrics" }]
-          }
-        }
-      )
-    }
-    memory_request = "768Mi"
+    values = [
+      <<-YAML
+      podAnnotations:
+        "ad.datadoghq.com/controller.checks": |
+          karpenter:
+            init_config: {}
+            instances:
+              - openmetrics_endpoint: http://%%host%%:8080/metrics
+      controller:
+        resources:
+          requests:
+            cpu: 0.5
+            memory: "768Mi"
+      YAML
+    ]
   }
+
 
   vpc = {
     enabled = true
@@ -130,16 +135,42 @@ module "datadog" {
   environment    = "sandbox"
   product_name   = "dai"
 
-  # Example: how to override specs in the Datadog Custom Resource
-  datadog_agent_helm_values = [
-    { name = "spec.features.apm.enabled", value = false },
-    { name = "spec.features.logCollection.enabled", value = false },
-    { name = "spec.override.clusterAgent.replicas", value = 3 }
-  ]
+  datadog_operator = {
+    chart_version = "2.9.1"
 
-  datadog_agent_version_fargate = "7.57.2" # github-releases/DataDog/datadog-agent
-  datadog = {
-    operator_chart_version = "1.8.1" # github-releases/DataDog/datadog-operator
+    values = [
+      <<-YAML
+      remoteConfiguration:
+        enabled: true
+      YAML
+    ]
+
+
+  }
+
+  # Example: how to override specs in the Datadog Custom Resource
+  datadog_agent = {
+    values = [
+      <<-YAML
+      spec:
+        override:
+          clusterAgent:
+            replicas: 1
+      YAML
+    ]
+
+    set = [
+      {
+        name  = "spec.features.apm.enabled",
+        value = false
+      },
+      {
+        name  = "spec.features.logCollection.enabled",
+        value = false
+      },
+    ]
+
+    agent_version_fargate = "7.57.2"
   }
 
   depends_on = [module.k8s_platform]

--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -135,43 +135,37 @@ module "datadog" {
   environment    = "sandbox"
   product_name   = "dai"
 
-  datadog_operator = {
-    chart_version = "2.9.1"
-
-    values = [
-      <<-YAML
-      remoteConfiguration:
-        enabled: true
-      YAML
-    ]
+  datadog_operator_helm_values = [
+    <<-YAML
+    remoteConfiguration:
+      enabled: true
+    YAML
+  ]
 
 
-  }
+  datadog_operator_helm_set = [
+    {
+      name  = "replicas"
+      value = 2
+    }
+  ]
 
   # Example: how to override specs in the Datadog Custom Resource
-  datadog_agent = {
-    values = [
-      <<-YAML
-      spec:
-        override:
-          clusterAgent:
-            replicas: 1
-      YAML
-    ]
+  datadog_agent_helm_values = [
+    <<-YAML
+    spec:
+      override:
+        clusterAgent:
+          replicas: 1
+    YAML
+  ]
 
-    set = [
-      {
-        name  = "spec.features.apm.enabled",
-        value = false
-      },
-      {
-        name  = "spec.features.logCollection.enabled",
-        value = false
-      },
-    ]
-
-    agent_version_fargate = "7.57.2"
-  }
+  datadog_agent_helm_set = [
+    {
+      name  = "spec.features.admissionController.agentSidecarInjection.image.tag",
+      value = "7.57.2"
+    }
+  ]
 
   depends_on = [module.k8s_platform]
 }

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -11,8 +11,6 @@ locals {
     subnet_cidrs = try(var.karpenter.subnet_cidrs, module.network.grouped_networks.karpenter)
 
     namespace = "kube-system"
-    # TODO: move to helm value inputs
-    pod_annotations = try(var.karpenter.pod_annotations, {})
   }
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
@@ -65,7 +63,6 @@ resource "helm_release" "karpenter_release" {
     logLevel: info
     dnsPolicy: Default
     replicas: 2
-    podAnnotations: ${jsonencode(local.karpenter.pod_annotations)}
     controller:
       resources:
         requests:

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -1,20 +1,50 @@
-# Datadog
+# Datadog Operator
 
 Deploy the Datadog Operator and the Datadog Agent
 
 ```hcl
 module "datadog" {
-  source  = "tx-pts-dai/kubernetes-platform/aws//modules/datadog"
-  version = ...
+  source = "../../modules/datadog"
 
-  cluster_name   = module.k8s_platform.eks.cluster_name
-  datadog_secret = "secret-name"
-  environment    = "sandbox"
-  product_name   = "my-product"
+  cluster_name   = "my-cluster"
+  datadog_secret = "secretsmanager/secret/namespace"
+  environment    = "example"
+  product_name   = "dai"
 
-  depends_on = [module.k8s_platform]
+  datadog_operator_helm_values = {
+    values = [
+      <<-YAML
+      remoteConfiguration:
+        enabled: true
+      YAML
+    ]
+  }
+
+  datadog_operator_helm_set = [
+    {
+      name  = "replicas"
+      value = 2
+    }
+  ]
+
+  datadog_agent_helm_values = [
+    <<-YAML
+    spec:
+      override:
+        clusterAgent:
+          replicas: 1
+    YAML
+  ]
+
+  datadog_agent_helm_set = [
+    {
+      name  = "spec.features.admissionController.agentSidecarInjection.image.tag",
+      value = "7.57.2"
+    }
+  ]
 }
 ```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -58,9 +88,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
-| <a name="input_datadog_agent"></a> [datadog\_agent](#input\_datadog\_agent) | Datadog Agent configurations | `any` | `{}` | no |
-| <a name="input_datadog_agent_version_fargate"></a> [datadog\_agent\_version\_fargate](#input\_datadog\_agent\_version\_fargate) | Version of the datadog agent injected in Fargate | `string` | `"7.57.2"` | no |
-| <a name="input_datadog_operator"></a> [datadog\_operator](#input\_datadog\_operator) | Datadog Operator configurations | `any` | `{}` | no |
+| <a name="input_datadog_agent_helm_set"></a> [datadog\_agent\_helm\_set](#input\_datadog\_agent\_helm\_set) | List of Datadog Agent custom resource set values | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_datadog_agent_helm_values"></a> [datadog\_agent\_helm\_values](#input\_datadog\_agent\_helm\_values) | List of Datadog Agent custom resource values | `list(string)` | `[]` | no |
+| <a name="input_datadog_operator_helm_set"></a> [datadog\_operator\_helm\_set](#input\_datadog\_operator\_helm\_set) | List of Datadog Operator Helm set values | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_datadog_operator_helm_values"></a> [datadog\_operator\_helm\_values](#input\_datadog\_operator\_helm\_values) | List of Datadog Operator Helm values | `list(string)` | `[]` | no |
+| <a name="input_datadog_operator_helm_version"></a> [datadog\_operator\_helm\_version](#input\_datadog\_operator\_helm\_version) | Version of the datadog operator chart | `string` | `"2.9.2"` | no |
 | <a name="input_datadog_secret"></a> [datadog\_secret](#input\_datadog\_secret) | Name of the datadog secret in Secrets Manager | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of the environment | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace for Datadog resources | `string` | `"monitoring"` | no |

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -38,15 +38,14 @@ module "datadog" {
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_datadog_operator"></a> [datadog\_operator](#module\_datadog\_operator) | aws-ia/eks-blueprints-addon/aws | >= 1.0 |
+No modules.
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [helm_release.datadog_agent](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.datadog_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.datadog_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.datadog_secrets_fargate](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.fargate_cluster_role](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
@@ -59,10 +58,9 @@ module "datadog" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
-| <a name="input_datadog"></a> [datadog](#input\_datadog) | Object of Datadog configurations | <pre>object({<br/>    agent_api_key_name            = optional(string) # by default it uses the cluster name<br/>    agent_app_key_name            = optional(string) # by default it uses the cluster name<br/>    operator_chart_version        = optional(string)<br/>    custom_resource_chart_version = optional(string)<br/>  })</pre> | `{}` | no |
-| <a name="input_datadog_agent_helm_values"></a> [datadog\_agent\_helm\_values](#input\_datadog\_agent\_helm\_values) | List of Datadog Agent custom resource values. https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_datadog_agent"></a> [datadog\_agent](#input\_datadog\_agent) | Datadog Agent configurations | `any` | `{}` | no |
 | <a name="input_datadog_agent_version_fargate"></a> [datadog\_agent\_version\_fargate](#input\_datadog\_agent\_version\_fargate) | Version of the datadog agent injected in Fargate | `string` | `"7.57.2"` | no |
-| <a name="input_datadog_operator_helm_values"></a> [datadog\_operator\_helm\_values](#input\_datadog\_operator\_helm\_values) | List of Datadog Operator values | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | <pre>[<br/>  {<br/>    "name": "resources.requests.cpu",<br/>    "value": "10m"<br/>  },<br/>  {<br/>    "name": "resources.requests.memory",<br/>    "value": "50Mi"<br/>  }<br/>]</pre> | no |
+| <a name="input_datadog_operator"></a> [datadog\_operator](#input\_datadog\_operator) | Datadog Operator configurations | `any` | `{}` | no |
 | <a name="input_datadog_secret"></a> [datadog\_secret](#input\_datadog\_secret) | Name of the datadog secret in Secrets Manager | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of the environment | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace for Datadog resources | `string` | `"monitoring"` | no |

--- a/modules/datadog/main.tf
+++ b/modules/datadog/main.tf
@@ -6,7 +6,7 @@ resource "helm_release" "datadog_operator" {
   chart            = "datadog-operator"
   namespace        = var.namespace
   max_history      = 3
-  version          = try(var.datadog_operator.chart_version, "2.9.2") # github-releases/DataDog/datadog-operator
+  version          = var.datadog_operator_helm_version
   atomic           = true
   cleanup_on_fail  = true
   create_namespace = true
@@ -52,10 +52,10 @@ resource "helm_release" "datadog_operator" {
       allowReadAllResources: true
 
     YAML
-  ], try(var.datadog_operator.values, []))
+  ], var.datadog_operator_helm_values)
 
   dynamic "set" {
-    for_each = try(var.datadog_operator.set, [])
+    for_each = var.datadog_operator_helm_set
 
     content {
       name  = set.value.name
@@ -79,6 +79,7 @@ resource "helm_release" "datadog_secrets" {
   chart            = "custom-resources"
   version          = "0.1.2"
   namespace        = var.namespace
+  max_history      = 3
   create_namespace = true
 
   values = [
@@ -109,11 +110,12 @@ resource "helm_release" "datadog_secrets" {
 }
 
 resource "helm_release" "datadog_secrets_fargate" {
-  name       = "datadog-secrets-fargate"
-  repository = "https://dnd-it.github.io/helm-charts"
-  chart      = "custom-resources"
-  version    = "0.1.2"
-  namespace  = "kube-system"
+  name        = "datadog-secrets-fargate"
+  repository  = "https://dnd-it.github.io/helm-charts"
+  chart       = "custom-resources"
+  version     = "0.1.2"
+  namespace   = "kube-system"
+  max_history = 3
 
   values = [
     <<-YAML
@@ -146,11 +148,12 @@ resource "helm_release" "datadog_secrets_fargate" {
 # Datadog Agent - available specs options https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
 
 resource "helm_release" "datadog_agent" {
-  name       = "datadog-agent"
-  repository = "https://dnd-it.github.io/helm-charts"
-  chart      = "custom-resources"
-  version    = "0.1.2"
-  namespace  = var.namespace
+  name        = "datadog-agent"
+  repository  = "https://dnd-it.github.io/helm-charts"
+  chart       = "custom-resources"
+  version     = "0.1.2"
+  namespace   = var.namespace
+  max_history = 3
 
   values = concat([
     <<-YAML
@@ -189,7 +192,7 @@ resource "helm_release" "datadog_agent" {
             registry: public.ecr.aws/datadog
             image:
               name: agent
-              tag: ${var.datadog_agent_version_fargate}
+              tag: 7
             provider: fargate
             profiles:
               - env:
@@ -243,10 +246,10 @@ resource "helm_release" "datadog_agent" {
                 limits:
                   memory: 100Mi
   YAML
-  ], try(var.datadog_agent.values, []))
+  ], var.datadog_agent_helm_values)
 
   dynamic "set" {
-    for_each = try(var.datadog_agent.set, [])
+    for_each = var.datadog_agent_helm_set
 
     content {
       name  = set.value.name

--- a/modules/datadog/migrations.tf
+++ b/modules/datadog/migrations.tf
@@ -1,0 +1,4 @@
+moved {
+  from = module.datadog_operator.helm_release.this[0]
+  to   = helm_release.datadog_operator
+}

--- a/modules/datadog/variables.tf
+++ b/modules/datadog/variables.tf
@@ -9,48 +9,21 @@ variable "cluster_name" {
   type        = string
 }
 
-
 variable "environment" {
   description = "Name of the environment"
   type        = string
 }
 
-variable "datadog" {
-  description = "Object of Datadog configurations"
-  type = object({
-    agent_api_key_name            = optional(string) # by default it uses the cluster name
-    agent_app_key_name            = optional(string) # by default it uses the cluster name
-    operator_chart_version        = optional(string)
-    custom_resource_chart_version = optional(string)
-  })
-  default = {}
+variable "datadog_operator" {
+  description = "Datadog Operator configurations"
+  type        = any
+  default     = {}
 }
 
-variable "datadog_agent_helm_values" {
-  description = "List of Datadog Agent custom resource values. https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md"
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default = []
-}
-
-variable "datadog_operator_helm_values" {
-  description = "List of Datadog Operator values"
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default = [
-    {
-      name  = "resources.requests.cpu"
-      value = "10m"
-    },
-    {
-      name  = "resources.requests.memory"
-      value = "50Mi"
-    },
-  ]
+variable "datadog_agent" {
+  description = "Datadog Agent configurations"
+  type        = any
+  default     = {}
 }
 
 variable "datadog_secret" {

--- a/modules/datadog/variables.tf
+++ b/modules/datadog/variables.tf
@@ -1,9 +1,3 @@
-variable "namespace" {
-  description = "Namespace for Datadog resources"
-  type        = string
-  default     = "monitoring"
-}
-
 variable "cluster_name" {
   description = "Name of the cluster"
   type        = string
@@ -14,30 +8,54 @@ variable "environment" {
   type        = string
 }
 
-variable "datadog_operator" {
-  description = "Datadog Operator configurations"
-  type        = any
-  default     = {}
-}
-
-variable "datadog_agent" {
-  description = "Datadog Agent configurations"
-  type        = any
-  default     = {}
-}
-
 variable "datadog_secret" {
   description = "Name of the datadog secret in Secrets Manager"
   type        = string
 }
 
-variable "datadog_agent_version_fargate" {
-  description = "Version of the datadog agent injected in Fargate"
-  type        = string
-  default     = "7.57.2" # github-releases/DataDog/datadog-agent"
-}
-
 variable "product_name" {
   description = "Value of the product tag added to all metrics and logs sent to datadog"
   type        = string
+}
+
+variable "namespace" {
+  description = "Namespace for Datadog resources"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "datadog_operator_helm_version" {
+  description = "Version of the datadog operator chart"
+  type        = string
+  default     = "2.9.2" # renovate: datasource=github-releases packageName=DataDog/datadog-operator
+}
+
+variable "datadog_operator_helm_values" {
+  description = "List of Datadog Operator Helm values"
+  type        = list(string)
+  default     = []
+}
+
+variable "datadog_operator_helm_set" {
+  description = "List of Datadog Operator Helm set values"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "datadog_agent_helm_values" {
+  description = "List of Datadog Agent custom resource values"
+  type        = list(string)
+  default     = []
+}
+
+variable "datadog_agent_helm_set" {
+  description = "List of Datadog Agent custom resource set values"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
 }


### PR DESCRIPTION
enable extra operator features
align the config logic to match the rest of the platform module

## Description


## Motivation and Context
Align the datadog module to use the same methods for updating values as the rest of the module. 
## Breaking Changes
Removed some variables but they were not used externally. 
## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
