### PR TITLE
fix: update karpenter resource chart

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -104,7 +104,7 @@ resource "helm_release" "karpenter_release" {
 resource "helm_release" "karpenter_resources" {
   name       = "karpenter-resources"
   chart      = "karpenter-resources"
-  version    = "0.3.1"
+  version    = "0.3.2"
   repository = "https://dnd-it.github.io/helm-charts"
   namespace  = local.karpenter.namespace
 


### PR DESCRIPTION
bug: if multiple node pools defined, the doc separator was put on the previous line making that doc ignored

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
