### PR TITLE
feat: Adding example for enabling datadog external metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="module_argocd"></a> [argocd](#module\_argocd) | ./modules/argocd | n/a |
 | <a name="module_downscaler"></a> [downscaler](#module\_downscaler) | tx-pts-dai/downscaler/kubernetes | 0.3.1 |
 | <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 5.55.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.35.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.36.0 |
 | <a name="module_fluent_operator"></a> [fluent\_operator](#module\_fluent\_operator) | ./modules/addon | n/a |
 | <a name="module_grafana"></a> [grafana](#module\_grafana) | ./modules/addon | n/a |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 20.35.0 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 20.36.0 |
 | <a name="module_karpenter_security_group"></a> [karpenter\_security\_group](#module\_karpenter\_security\_group) | ./modules/security-group | n/a |
 | <a name="module_network"></a> [network](#module\_network) | ./modules/network | n/a |
 | <a name="module_okta_secrets"></a> [okta\_secrets](#module\_okta\_secrets) | ./modules/addon | n/a |

--- a/examples/datadog/main.tf
+++ b/examples/datadog/main.tf
@@ -151,9 +151,14 @@ module "datadog" {
   ]
 
   # Example: how to override specs in the Datadog Custom Resource
+  # How to update the number of clusterAgent replicas and enable datadog agent as external metrics server
   datadog_agent_helm_values = [
     <<-YAML
     spec:
+      features:
+        externalMetricsServer:
+          enabled: true
+          useDatadogMetrics: true
       override:
         clusterAgent:
           replicas: 1

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -23,7 +23,7 @@ See the [network example](../../example/network) how to use it and how to retrie
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | ./../ssm | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.19.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.21.0 |
 
 ## Resources
 


### PR DESCRIPTION
## Description
Updating the Datadog example to show how to enable Datadog agen as external metrics server

## Motivation and Context
This configuration allows the possibility to use netrics collected by the agent in HPA

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
- I validated that the external metrics servers is enabled in DAI sandbox, by looking at the DD cluster agent deployment:

```
    - name: DD_EXTERNAL_METRICS_PROVIDER_USE_DATADOGMETRIC_CRD                                                                                                                                                                                 
      value: "true"
```
