### PR TITLE
fix: update karpenter resource chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.42.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.12 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.27 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11 |
@@ -175,8 +175,8 @@ as described in the `.pre-commit-config.yaml` file
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.42.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.42 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.12 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.27 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
 

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -104,7 +104,7 @@ resource "helm_release" "karpenter_release" {
 resource "helm_release" "karpenter_resources" {
   name       = "karpenter-resources"
   chart      = "karpenter-resources"
-  version    = "0.3.2"
+  version    = "0.3.3"
   repository = "https://dnd-it.github.io/helm-charts"
   namespace  = local.karpenter.namespace
 

--- a/modules/addon/README.md
+++ b/modules/addon/README.md
@@ -134,16 +134,16 @@ module "eks_blueprints_addon" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47, < 6.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.9 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47, < 6.0.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.9 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.11 |
 
 ## Modules

--- a/modules/addon/versions.tf
+++ b/modules/addon/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 4.47, < 6.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = "~> 2.9"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/argocd/README.md
+++ b/modules/argocd/README.md
@@ -42,15 +42,15 @@ module "spoke" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.9 |
 
 ## Modules
 

--- a/modules/argocd/versions.tf
+++ b/modules/argocd/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -51,7 +51,7 @@ module "datadog" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.27 |

--- a/modules/datadog/versions.tf
+++ b/modules/datadog/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 5.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/lacework/README.md
+++ b/modules/lacework/README.md
@@ -16,7 +16,7 @@ module "lacework" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | >= 2.0.0 |
 
@@ -24,7 +24,7 @@ module "lacework" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | >= 2.0.0 |
 

--- a/modules/lacework/versions.tf
+++ b/modules/lacework/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -10,13 +10,13 @@ See the [network example](../../example/network) how to use it and how to retrie
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.42.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.42 |
 
 ## Modules
 

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.42.0"
+      version = "~> 5.42"
     }
   }
 }

--- a/modules/security-group/README.md
+++ b/modules/security-group/README.md
@@ -8,13 +8,13 @@ This module creates a security group and rules.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/modules/security-group/versions.tf
+++ b/modules/security-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/ssm/README.md
+++ b/modules/ssm/README.md
@@ -125,13 +125,13 @@ The `filtered_parameters` local variable is used to filter parameters based on t
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.42.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.42 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.42 |
 
 ## Modules
 

--- a/modules/ssm/versions.tf
+++ b/modules/ssm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.42.0"
+      version = "~> 5.42"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.42.0"
+      version = "~> 5.42"
     }
     kubectl = {
       source  = "alekc/kubectl"
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.12"
+      version = "~> 2.12"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Description
- Updating Karpenter helm chart version
- Preventing  AWS terraform provider v6 usage, due to breaking changes
- Preventing  Helm terraform provider v3 usage, due to breaking changes

## Motivation and Context
The new chart increases the default value for `consolidateAfter` from 5m to 1h. 5m has proven to cause a too much aggressive consolidation and therefore doesn't fit as default value.


## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
