### PR TITLE
feat: upgrade external-secrets and aws lb control

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -93,7 +93,7 @@ module "addons" {
     role_name_prefix = false
 
     # renovate: datasource=helm depName=aws-load-balancer-controller registryUrl=https://aws.github.io/eks-charts
-    chart_version = "1.12.0"
+    chart_version = "1.13.3"
 
     wait = true
 
@@ -129,6 +129,10 @@ module "addons" {
 
   enable_external_secrets = var.enable_external_secrets && var.create_addons
   external_secrets = {
+
+    # renovate: datasource=helm depName=external-secrets registryUrl=https://charts.external-secrets.io
+    chart_version = "0.16.2"
+
     wait             = true
     role_name        = "external-secrets-${local.id}"
     role_name_prefix = false


### PR DESCRIPTION
## Description
0.16.2 is the last version of external secrets v1beta support

bump aws lb controller for gateway api support

## Motivation and Context
Want to migrate to v1 eso api to get needed features

## Breaking Changes
None - apis dont change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
