### PR TITLE
fix: revert to use local.id for role name suffix

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -11,7 +11,7 @@ module "ebs_csi_driver_irsa" {
 
   create_role = var.create_addons
 
-  role_name = "ebs-csi-driver-${local.stack_name}"
+  role_name = "ebs-csi-driver-${local.id}"
 
   attach_ebs_csi_policy = true
 
@@ -89,7 +89,7 @@ module "addons" {
   # TODO: aws lb controller should be one of the last things deleted, so ing objects can be cleaned up
   enable_aws_load_balancer_controller = var.enable_aws_load_balancer_controller && var.create_addons
   aws_load_balancer_controller = {
-    role_name            = "lb-controller-${local.stack_name}"
+    role_name            = "lb-controller-${local.id}"
     role_name_use_prefix = false
 
     # renovate: datasource=helm depName=aws-load-balancer-controller registryUrl=https://aws.github.io/eks-charts
@@ -114,7 +114,7 @@ module "addons" {
     "arn:aws:route53:::hostedzone/*",
   ]
   external_dns = {
-    role_name        = "external-dns-${local.stack_name}"
+    role_name        = "external-dns-${local.id}"
     role_name_prefix = false
 
     values = try(var.external_dns.values, [])
@@ -134,7 +134,7 @@ module "addons" {
     chart_version = "0.16.2"
 
     wait             = true
-    role_name        = "external-secrets-${local.stack_name}"
+    role_name        = "external-secrets-${local.id}"
     role_name_prefix = false
 
     values = try(var.external_secrets.values, [])
@@ -144,7 +144,7 @@ module "addons" {
   enable_fargate_fluentbit = var.enable_fargate_fluentbit
   fargate_fluentbit = {
     fargate_fluentbit_cw_log_group_name = "/aws/eks/${module.eks.cluster_name}/fargate"
-    role_name                           = "fargate-fluentbit-${local.stack_name}"
+    role_name                           = "fargate-fluentbit-${local.id}"
     role_name_prefix                    = false
 
     values = try(var.fargate_fluentbit.values, [])

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -22,10 +22,10 @@ module "karpenter" {
   enable_irsa                     = true
   irsa_oidc_provider_arn          = module.eks.oidc_provider_arn
   irsa_namespace_service_accounts = ["${local.karpenter.namespace}:karpenter"]
-  iam_role_name                   = "karpenter-${local.stack_name}"
+  iam_role_name                   = "karpenter-${local.id}"
   iam_role_use_name_prefix        = false
 
-  node_iam_role_name              = "karpenter-node-${local.stack_name}"
+  node_iam_role_name              = "karpenter-node-${local.id}"
   node_iam_role_use_name_prefix   = false
   node_iam_role_attach_cni_policy = false
   node_iam_role_additional_policies = {

--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,11 @@ resource "time_static" "timestamp_id" {
 # and this create a tags merge issue,
 
 locals {
-  id = var.enable_timestamp_id ? format("%08x", time_static.timestamp_id[0].unix) : null
+  id = var.enable_timestamp_id ? format("%08x", time_static.timestamp_id[0].unix) : local.name
 
   # This is not the best way to handle naming compatibility but its a simple approach to fix renovate PR deployments
   name       = coalesce(replace(var.name, "/", "-"), replace(basename(path.root), "_", "-"))
-  stack_name = local.id != null ? "${local.name}-${local.id}" : local.name
+  stack_name = local.id != local.name ? "${local.name}-${local.id}" : local.name
 
   tags = merge(var.tags, {
     StackName = local.stack_name
@@ -135,7 +135,7 @@ module "eks" {
           labels    = { "app.kubernetes.io/name" = "karpenter" }
         },
       ]
-      iam_role_name            = "karpenter-fargate-${local.stack_name}"
+      iam_role_name            = "karpenter-fargate-${local.id}"
       iam_role_use_name_prefix = false
     }
   }
@@ -190,7 +190,7 @@ module "vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.55.0"
 
-  role_name = "vpc-cni-${local.stack_name}"
+  role_name = "vpc-cni-${local.id}"
 
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true


### PR DESCRIPTION
## Description
this change in v3 forced renaming of roles and caused already deployed clusters to redeploy resources

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
