### PR TITLE
fix: allow secerets operator to get secrets

### DIFF
--- a/addons.tf
+++ b/addons.tf
@@ -172,7 +172,10 @@ module "external_secrets_pod_identity" {
   external_secrets_policy_name = "external-secrets-pod-identity-${local.id}"
   use_name_prefix              = false
 
-  attach_external_secrets_policy = true
+  attach_external_secrets_policy        = true
+  external_secrets_create_permission    = true
+  external_secrets_ssm_parameter_arns   = ["*"]
+  external_secrets_secrets_manager_arns = ["*"]
 
   associations = {
     controller = {


### PR DESCRIPTION
## Description
Allow secrets operator to get secrets

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
