### PR TITLE
fix: patch karpeneter resources chart

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -478,7 +478,7 @@ resource "helm_release" "karpenter_release" {
 resource "helm_release" "karpenter_resources" {
   name       = "karpenter-resources"
   chart      = "karpenter-resources"
-  version    = "1.0.0"
+  version    = "1.0.1"
   repository = "https://dnd-it.github.io/helm-charts"
   namespace  = local.karpenter.namespace
 


### PR DESCRIPTION
the chart schemas was incorrect

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
