### PR TITLE
feat: remove helm chart from argocd module

### DIFF
--- a/modules/argocd/README.md
+++ b/modules/argocd/README.md
@@ -1,6 +1,6 @@
 # ArgoCD
 
-This module deploys ArgoCD as either the hub or spoke controller. This will deploy the default ArgoCD Helm chart and all the necessary IAM roles and policies.
+This module deploys ArgoCD supporting resources for the hub or spoke. All the necessary IAM roles and policies.
 
 ## Examples
 
@@ -30,8 +30,6 @@ module "spoke" {
 
   cluster_name = "example-cluster"
 
-  cluster_secret_suffix = "sandbox"
-
   hub_iam_role_arn = "arn:aws:iam::123456789012:role/argocd-example-cluster-hub"
 }
 ```
@@ -43,14 +41,12 @@ module "spoke" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0.2 |
 
 ## Modules
 
@@ -69,7 +65,6 @@ No modules.
 | [aws_iam_role.argocd_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.argocd_spoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.argocd_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [helm_release.argocd](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.argocd_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.argocd_controller_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -83,9 +78,6 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Create the ArgoCD resources | `bool` | `true` | no |
 | <a name="input_enable_hub"></a> [enable\_hub](#input\_enable\_hub) | Enable ArgoCD Hub | `bool` | `false` | no |
 | <a name="input_enable_spoke"></a> [enable\_spoke](#input\_enable\_spoke) | Enable ArgoCD Spoke | `bool` | `false` | no |
-| <a name="input_helm_set"></a> [helm\_set](#input\_helm\_set) | Set values to pass to the Helm chart | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>    type  = optional(string)<br/>  }))</pre> | `[]` | no |
-| <a name="input_helm_values"></a> [helm\_values](#input\_helm\_values) | Values to pass to the Helm chart | `list(string)` | `[]` | no |
-| <a name="input_helm_version"></a> [helm\_version](#input\_helm\_version) | Version of the Helm chart to install | `string` | `"7.8.26"` | no |
 | <a name="input_hub_iam_role_arn"></a> [hub\_iam\_role\_arn](#input\_hub\_iam\_role\_arn) | (Deprecated, use hub\_iam\_role\_arns) IAM Role ARN for ArgoCD Hub. This is required for spoke clusters | `string` | `null` | no |
 | <a name="input_hub_iam_role_arns"></a> [hub\_iam\_role\_arns](#input\_hub\_iam\_role\_arns) | A list of ArgoCD Hub IAM Role ARNs, enabling hubs to access spoke clusters. This is required for spoke clusters. | `list(string)` | `null` | no |
 | <a name="input_hub_iam_role_name"></a> [hub\_iam\_role\_name](#input\_hub\_iam\_role\_name) | IAM Role Name for ArgoCD Hub. This is referenced by the Spoke clusters | `string` | `"argocd-controller"` | no |

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -84,28 +84,6 @@ resource "aws_eks_pod_identity_association" "argocd_server" {
   tags = var.tags
 }
 
-resource "helm_release" "argocd" {
-  count = var.create && var.enable_hub ? 1 : 0
-
-  name             = "argocd"
-  description      = "A Helm chart to install the ArgoCD"
-  chart            = "argo-cd"
-  version          = var.helm_version
-  repository       = "https://argoproj.github.io/argo-helm"
-  namespace        = var.namespace
-  wait             = true
-  create_namespace = true
-
-  # https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml
-  values = var.helm_values
-
-  set = var.helm_set
-
-  depends_on = [
-    aws_iam_role.argocd_controller
-  ]
-}
-
 ##################### ArgoCD Spoke ###########################################
 locals {
   # Remove this when the variable hub_iam_role_arn is deprecated

--- a/modules/argocd/variables.tf
+++ b/modules/argocd/variables.tf
@@ -58,28 +58,3 @@ variable "namespace" {
 
   default = "argocd"
 }
-
-variable "helm_version" {
-  description = "Version of the Helm chart to install"
-  type        = string
-
-  default = "7.8.26" # renovate: datasource=helm depName=argo-cd repositoryUrl=https://argoproj.github.io/argo-helm
-}
-
-variable "helm_values" {
-  description = "Values to pass to the Helm chart"
-  type        = list(string)
-
-  default = []
-}
-
-variable "helm_set" {
-  description = "Set values to pass to the Helm chart"
-  type = list(object({
-    name  = string
-    value = string
-    type  = optional(string)
-  }))
-
-  default = []
-}

--- a/modules/argocd/versions.tf
+++ b/modules/argocd/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 3.0.2"
-    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Upgrading the helm provider to v3 caused the helm resources to reapply which was an old verison since we self manage argocd. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
