### PR TITLE
fix: create secret for karpenter datadog sidecar

### DIFF
--- a/modules/datadog/README.md
+++ b/modules/datadog/README.md
@@ -82,6 +82,7 @@ No modules.
 | [kubernetes_annotations.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) | resource |
 | [kubernetes_namespace_v1.datadog](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_secret.datadog_keys](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.datadog_keys_karpenter](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_secretsmanager_secret.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_secretsmanager_secret_version.datadog](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |

--- a/modules/datadog/main.tf
+++ b/modules/datadog/main.tf
@@ -79,6 +79,20 @@ locals {
   datadog_secret = jsondecode(data.aws_secretsmanager_secret_version.datadog.secret_string)
 }
 
+resource "kubernetes_secret" "datadog_keys_karpenter" {
+  metadata {
+    name      = "datadog-keys"
+    namespace = "kube-system"
+  }
+
+  data = {
+    "api-key" = local.datadog_secret["DD_API_KEY"]
+    "app-key" = local.datadog_secret["DD_APP_KEY"]
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret" "datadog_keys" {
   metadata {
     name      = "datadog-keys"


### PR DESCRIPTION
## Description
Add secret to kube-system for karpenter datadog sidecar

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
