### PR TITLE
feat(argocd-registration): dynamic cluster registration + scoped ACK policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ as described in the `.pre-commit-config.yaml` file
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | >= 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0.2 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.27 |
@@ -121,7 +122,7 @@ as described in the `.pre-commit-config.yaml` file
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0.2 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.27 |
@@ -130,10 +131,11 @@ as described in the `.pre-commit-config.yaml` file
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_ack_capability"></a> [ack\_capability](#module\_ack\_capability) | terraform-aws-modules/eks/aws//modules/capability | 21.15.1 |
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | 6.3.0 |
 | <a name="module_argocd"></a> [argocd](#module\_argocd) | ./modules/argocd | n/a |
+| <a name="module_argocd_registration"></a> [argocd\_registration](#module\_argocd\_registration) | ./modules/argocd-registration | n/a |
 | <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_aws_gateway_controller_pod_identity"></a> [aws\_gateway\_controller\_pod\_identity](#module\_aws\_gateway\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
 | <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.7.0 |
@@ -152,11 +154,12 @@ as described in the `.pre-commit-config.yaml` file
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_eks_access_entry.k8s_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_entry) | resource |
 | [aws_eks_access_policy_association.k8s_access_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_policy_association) | resource |
 | [aws_eks_access_policy_association.k8s_access_predefined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_policy_association) | resource |
+| [aws_iam_policy.ack_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ecr_passthrough](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -175,6 +178,7 @@ as described in the `.pre-commit-config.yaml` file
 | [time_static.timestamp_id](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.ack_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr_passthrough](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.k8s_access_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -188,10 +192,11 @@ as described in the `.pre-commit-config.yaml` file
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_ack_iam_policy_arn"></a> [ack\_iam\_policy\_arn](#input\_ack\_iam\_policy\_arn) | IAM policy ARN to attach to the ACK capability role. Defaults to AdministratorAccess if not specified. | `string` | `null` | no |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_ack_iam_policy_arn"></a> [ack\_iam\_policy\_arn](#input\_ack\_iam\_policy\_arn) | IAM policy ARN to attach to the ACK capability role. When null (default), a purpose-built policy covering ACM, Route53, IAM CRUD, and EKS pod-identity actions is created automatically. | `string` | `null` | no |
 | <a name="input_acm_certificate"></a> [acm\_certificate](#input\_acm\_certificate) | ACM certificate configuration for the domain(s). Controls domain name, alternative domain names, wildcard configuration, and validation behavior.<br/>Options include:<br/>  - domain\_name: Primary domain name for the certificate. If not provided, uses base\_domain from other configuration.<br/>  - subject\_alternative\_names: List of additional domain names to include in the certificate.<br/>  - wildcard\_certificates: When true, adds a wildcard prefix (*.) to all domains in the certificate.<br/>  - prepend\_stack\_id: When true, prepends the stack identifier to each domain name. Only works after random\_string is created.<br/>  - wait\_for\_validation: When true, Terraform will wait for certificate validation to complete before proceeding. | <pre>object({<br/>    domain_name               = optional(string)<br/>    subject_alternative_names = optional(list(string), [])<br/>    wildcard_certificates     = optional(bool, false)<br/>    prepend_stack_id          = optional(bool, false)<br/>    wait_for_validation       = optional(bool, false)<br/>  })</pre> | `{}` | no |
 | <a name="input_argocd"></a> [argocd](#input\_argocd) | Argo CD configurations | <pre>object({<br/>    # Hub specific<br/>    enable_hub        = optional(bool, false)<br/>    namespace         = optional(string, "argocd")<br/>    hub_iam_role_name = optional(string, "argocd-controller")<br/><br/>    # Spoke specific<br/>    enable_spoke = optional(bool, false)<br/><br/>    hub_iam_role_arn  = optional(string, null)<br/>    hub_iam_role_arns = optional(list(string), null)<br/><br/>    # Common<br/>    tags = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_argocd_registration"></a> [argocd\_registration](#input\_argocd\_registration) | ArgoCD cluster registration config. Required when enable\_argocd\_registration = true. | <pre>object({<br/>    github_repository      = string<br/>    github_branch          = optional(string, "main")<br/>    argocd_hub_environment = optional(string, "prod")<br/>    cluster_labels = object({<br/>      cluster_group  = string<br/>      environment    = string<br/>      team           = string<br/>      promotion_tier = string<br/><br/>      enable_ack                          = optional(bool, false)<br/>      enable_adapter                      = optional(bool, false)<br/>      enable_aws_load_balancer_controller = optional(bool, false)<br/>      enable_cert_manager                 = optional(bool, false)<br/>      enable_datadog_operator             = optional(bool, false)<br/>      enable_downscaler                   = optional(bool, false)<br/>      enable_exporters                    = optional(bool, false)<br/>      enable_external_dns                 = optional(bool, false)<br/>      enable_external_dns_crossaccount    = optional(bool, false)<br/>      enable_external_secrets             = optional(bool, false)<br/>      enable_grafana                      = optional(bool, false)<br/>      enable_kargo                        = optional(bool, false)<br/>      enable_kube_prometheus_stack        = optional(bool, false)<br/>      enable_metrics_server               = optional(bool, false)<br/>      enable_reloader                     = optional(bool, false)<br/>      enable_tailscale_operator           = optional(bool, false)<br/>    })<br/>  })</pre> | `null` | no |
 | <a name="input_base_domain"></a> [base\_domain](#input\_base\_domain) | Base domain for the platform, used for ingress and ACM certificates | `string` | `null` | no |
 | <a name="input_cluster_admins"></a> [cluster\_admins](#input\_cluster\_admins) | Map of IAM roles to add as cluster admins<br/>  role\_arn: ARN of the IAM role to add as cluster admin<br/>  role\_name: Name of the IAM role to add as cluster admin<br/>  kubernetes\_groups: List of Kubernetes groups to add the role to (default: ["system:masters"])<br/><br/>role\_arn and role\_name are mutually exclusive, exactly one must be set. | <pre>map(object({<br/>    role_arn          = optional(string)<br/>    role_name         = optional(string)<br/>    kubernetes_groups = optional(list(string))<br/>  }))</pre> | `{}` | no |
 | <a name="input_create_addon_pod_identity_roles"></a> [create\_addon\_pod\_identity\_roles](#input\_create\_addon\_pod\_identity\_roles) | Create addon pod identities roles. If set to true, all roles will be created | `bool` | `true` | no |
@@ -199,6 +204,7 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="input_enable_ack"></a> [enable\_ack](#input\_enable\_ack) | Enable ACK (AWS Controllers for Kubernetes) EKS capability. Note: AdministratorAccess is attached by default. Use ack\_iam\_policy\_arn to override with a least-privilege policy. | `bool` | `true` | no |
 | <a name="input_enable_acm_certificate"></a> [enable\_acm\_certificate](#input\_enable\_acm\_certificate) | Enable ACM certificate | `bool` | `false` | no |
 | <a name="input_enable_argocd"></a> [enable\_argocd](#input\_enable\_argocd) | Enable Argo CD | `bool` | `false` | no |
+| <a name="input_enable_argocd_registration"></a> [enable\_argocd\_registration](#input\_enable\_argocd\_registration) | Automatically register this cluster with the ArgoCD hub by committing a cluster Secret YAML to the GitOps repository via the GitHub provider. | `bool` | `false` | no |
 | <a name="input_enable_ecr_passthrough_policy"></a> [enable\_ecr\_passthrough\_policy](#input\_enable\_ecr\_passthrough\_policy) | Enable the ECR pull-through cache policy for cluster nodes. This policy may grant additional ECR permissions, including automatic repository creation for pull-through cache repositories, and is not required for standard ECR image pulls. | `bool` | `false` | no |
 | <a name="input_enable_fargate_fluentbit"></a> [enable\_fargate\_fluentbit](#input\_enable\_fargate\_fluentbit) | Enable Fargate Fluentbit | `bool` | `true` | no |
 | <a name="input_enable_sso_admin_auto_discovery"></a> [enable\_sso\_admin\_auto\_discovery](#input\_enable\_sso\_admin\_auto\_discovery) | Enable automatic discovery of SSO admin roles. When disabled, only explicitly defined cluster\_admins are used. | `bool` | `true` | no |
@@ -220,9 +226,10 @@ as described in the `.pre-commit-config.yaml` file
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_ack"></a> [ack](#output\_ack) | Map of attributes for the ACK EKS capability |
 | <a name="output_argocd"></a> [argocd](#output\_argocd) | Map of attributes for the ArgoCD module |
+| <a name="output_argocd_registration"></a> [argocd\_registration](#output\_argocd\_registration) | ArgoCD cluster registration outputs (file path and commit SHA) |
 | <a name="output_eks"></a> [eks](#output\_eks) | Map of attributes for the EKS cluster |
 | <a name="output_karpenter"></a> [karpenter](#output\_karpenter) | Map of attributes for the Karpenter module |
 | <a name="output_kubernetes_access_role_arns"></a> [kubernetes\_access\_role\_arns](#output\_kubernetes\_access\_role\_arns) | Map of reusable Kubernetes access role names to their IAM role ARNs |

--- a/argocd-registration.tf
+++ b/argocd-registration.tf
@@ -1,0 +1,27 @@
+################################################################################
+# ArgoCD Dynamic Cluster Registration
+################################################################################
+
+module "argocd_registration" {
+  source = "./modules/argocd-registration"
+
+  create                 = var.enable_argocd_registration
+  github_repository      = try(var.argocd_registration.github_repository, "")
+  github_branch          = try(var.argocd_registration.github_branch, "main")
+  argocd_hub_environment = try(var.argocd_registration.argocd_hub_environment, "prod")
+
+  cluster_name          = module.eks.cluster_name
+  cluster_endpoint      = module.eks.cluster_endpoint
+  cluster_ca_data       = module.eks.cluster_certificate_authority_data
+  argocd_spoke_role_arn = module.argocd.spoke_iam_role_arn
+  aws_account_id        = data.aws_caller_identity.current.account_id
+  aws_region            = data.aws_region.current.name
+  vpc_cidr              = var.vpc.vpc_cidr
+
+  cluster_labels = try(var.argocd_registration.cluster_labels, null)
+
+  depends_on = [
+    module.argocd,
+    module.eks,
+  ]
+}

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -2,6 +2,87 @@
 # EKS Capabilities
 ################################################################################
 
+data "aws_iam_policy_document" "ack_controller" {
+  count = var.enable_ack && var.ack_iam_policy_arn == null ? 1 : 0
+
+  statement {
+    sid       = "ACMFull"
+    actions   = ["acm:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "Route53Full"
+    actions   = ["route53:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "IAMRolePolicyCRUD"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreatePolicy",
+      "iam:CreatePolicyVersion",
+      "iam:CreateRole",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListPolicies",
+      "iam:ListPolicyVersions",
+      "iam:ListRolePolicies",
+      "iam:ListRoles",
+      "iam:PutRolePolicy",
+      "iam:TagPolicy",
+      "iam:TagRole",
+      "iam:UntagPolicy",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EKSPodIdentity"
+    actions = [
+      "eks:CreatePodIdentityAssociation",
+      "eks:DeletePodIdentityAssociation",
+      "eks:DescribePodIdentityAssociation",
+      "eks:ListPodIdentityAssociations",
+      "eks:UpdatePodIdentityAssociation",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "IAMPassRole"
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["pods.eks.amazonaws.com", "eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "ack_controller" {
+  count = var.enable_ack && var.ack_iam_policy_arn == null ? 1 : 0
+
+  name        = "ack-controller-${local.id}"
+  description = "Least-privilege policy for ACK controllers (ACM, Route53, IAM CRUD, EKS pod identity)"
+  policy      = data.aws_iam_policy_document.ack_controller[0].json
+
+  tags = local.tags
+}
+
 module "ack_capability" {
   source  = "terraform-aws-modules/eks/aws//modules/capability"
   version = "21.15.1"
@@ -15,7 +96,10 @@ module "ack_capability" {
   iam_role_use_name_prefix = false
 
   iam_role_policies = {
-    ack = coalesce(var.ack_iam_policy_arn, "arn:aws:iam::aws:policy/AdministratorAccess")
+    ack = coalesce(
+      var.ack_iam_policy_arn,
+      one(aws_iam_policy.ack_controller[*].arn)
+    )
   }
 
   tags = local.tags

--- a/modules/argocd-registration/main.tf
+++ b/modules/argocd-registration/main.tf
@@ -1,0 +1,76 @@
+locals {
+  file_path = "configs/argocd/hub/${var.argocd_hub_environment}/clusters/${var.cluster_name}.yaml"
+
+  argocd_config = jsonencode({
+    awsAuthConfig = {
+      clusterName = var.cluster_name
+      roleARN     = var.argocd_spoke_role_arn
+    }
+    tlsClientConfig = {
+      insecure = false
+      caData   = var.cluster_ca_data
+    }
+  })
+
+  # Build the full label map — only include enable-* flags that are true
+  labels = merge(
+    {
+      "argocd.argoproj.io/secret-type" = "cluster"
+      "region"                         = var.aws_region
+      "cluster-name"                   = var.cluster_name
+      "aws-account-id"                 = var.aws_account_id
+      "cluster-group"                  = var.cluster_labels.cluster_group
+      "environment"                    = var.cluster_labels.environment
+      "team"                           = var.cluster_labels.team
+      "promotion-tier"                 = var.cluster_labels.promotion_tier
+    },
+    var.cluster_labels.enable_ack ? { "enable-ack" = "true" } : {},
+    var.cluster_labels.enable_adapter ? { "enable-adapter" = "true" } : {},
+    var.cluster_labels.enable_aws_load_balancer_controller ? { "enable-aws-load-balancer-controller" = "true" } : {},
+    var.cluster_labels.enable_cert_manager ? { "enable-cert-manager" = "true" } : {},
+    var.cluster_labels.enable_datadog_operator ? { "enable-datadog-operator" = "true" } : {},
+    var.cluster_labels.enable_downscaler ? { "enable-downscaler" = "true" } : {},
+    var.cluster_labels.enable_exporters ? { "enable-exporters" = "true" } : {},
+    var.cluster_labels.enable_external_dns ? { "enable-external-dns" = "true" } : {},
+    var.cluster_labels.enable_external_dns_crossaccount ? { "enable-external-dns-crossaccount" = "true" } : {},
+    var.cluster_labels.enable_external_secrets ? { "enable-external-secrets" = "true" } : {},
+    var.cluster_labels.enable_grafana ? { "enable-grafana" = "true" } : {},
+    var.cluster_labels.enable_kargo ? { "enable-kargo" = "true" } : {},
+    var.cluster_labels.enable_kube_prometheus_stack ? { "enable-kube-prometheus-stack" = "true" } : {},
+    var.cluster_labels.enable_metrics_server ? { "enable-metrics-server" = "true" } : {},
+    var.cluster_labels.enable_reloader ? { "enable-reloader" = "true" } : {},
+    var.cluster_labels.enable_tailscale_operator ? { "enable-tailscale-operator" = "true" } : {},
+  )
+
+  cluster_secret_content = templatefile("${path.module}/templates/cluster-secret.yaml.tpl", {
+    cluster_name     = var.cluster_name
+    labels           = local.labels
+    vpc_cidr         = var.vpc_cidr
+    cluster_endpoint = var.cluster_endpoint
+    argocd_config    = local.argocd_config
+  })
+}
+
+resource "github_repository_file" "cluster_secret" {
+  count = var.create ? 1 : 0
+
+  repository          = split("/", var.github_repository)[1]
+  branch              = var.github_branch
+  file                = local.file_path
+  content             = local.cluster_secret_content
+  commit_message      = "chore(argocd): register cluster ${var.cluster_name} [terraform]"
+  commit_author       = "Terraform"
+  commit_email        = "terraform@noreply"
+  overwrite_on_create = true
+
+  lifecycle {
+    # Deregistration is intentionally manual to prevent accidental cluster removal.
+    # To deregister: delete the file from Git, then remove this resource from state.
+    prevent_destroy = true
+
+    precondition {
+      condition     = var.argocd_spoke_role_arn != ""
+      error_message = "argocd_spoke_role_arn must be set. Ensure enable_argocd = true and argocd.enable_spoke = true in the parent module."
+    }
+  }
+}

--- a/modules/argocd-registration/outputs.tf
+++ b/modules/argocd-registration/outputs.tf
@@ -1,0 +1,9 @@
+output "file_path" {
+  description = "Path of the cluster Secret file committed to the GitOps repository"
+  value       = try(github_repository_file.cluster_secret[0].file, "")
+}
+
+output "commit_sha" {
+  description = "Git commit SHA of the last file write"
+  value       = try(github_repository_file.cluster_secret[0].commit_sha, "")
+}

--- a/modules/argocd-registration/templates/cluster-secret.yaml.tpl
+++ b/modules/argocd-registration/templates/cluster-secret.yaml.tpl
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${cluster_name}
+  namespace: argocd
+  labels:
+%{ for key, value in labels ~}
+    ${key}: "${value}"
+%{ endfor ~}
+  annotations:
+    config/vpc-cidr: "${vpc_cidr}"
+type: Opaque
+stringData:
+  name: "${cluster_name}"
+  server: "${cluster_endpoint}"
+  config: |
+    ${indent(4, argocd_config)}

--- a/modules/argocd-registration/variables.tf
+++ b/modules/argocd-registration/variables.tf
@@ -1,0 +1,85 @@
+variable "create" {
+  description = "Controls whether resources are created"
+  type        = bool
+  default     = true
+}
+
+variable "github_repository" {
+  description = "GitHub repository in owner/repo format (e.g. dnd-it/fission-argocd)"
+  type        = string
+  default     = ""
+}
+
+variable "github_branch" {
+  description = "Git branch to commit the cluster Secret file to"
+  type        = string
+  default     = "main"
+}
+
+variable "argocd_hub_environment" {
+  description = "Environment directory name under configs/argocd/hub/ — must match the subdirectory where this cluster should be registered (e.g. prod, dev)"
+  type        = string
+  default     = "prod"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "EKS cluster API server endpoint URL"
+  type        = string
+}
+
+variable "cluster_ca_data" {
+  description = "Base64-encoded CA certificate data for the EKS cluster"
+  type        = string
+}
+
+variable "argocd_spoke_role_arn" {
+  description = "IAM role ARN that the ArgoCD hub assumes to access this cluster"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID hosting the cluster"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region where the cluster is deployed"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block, stored as the config/vpc-cidr annotation on the cluster Secret"
+  type        = string
+}
+
+variable "cluster_labels" {
+  description = "ArgoCD cluster metadata and feature flags. All enable_* flags default to false."
+  type = object({
+    cluster_group  = string
+    environment    = string
+    team           = string
+    promotion_tier = string
+
+    enable_ack                          = optional(bool, false)
+    enable_adapter                      = optional(bool, false)
+    enable_aws_load_balancer_controller = optional(bool, false)
+    enable_cert_manager                 = optional(bool, false)
+    enable_datadog_operator             = optional(bool, false)
+    enable_downscaler                   = optional(bool, false)
+    enable_exporters                    = optional(bool, false)
+    enable_external_dns                 = optional(bool, false)
+    enable_external_dns_crossaccount    = optional(bool, false)
+    enable_external_secrets             = optional(bool, false)
+    enable_grafana                      = optional(bool, false)
+    enable_kargo                        = optional(bool, false)
+    enable_kube_prometheus_stack        = optional(bool, false)
+    enable_metrics_server               = optional(bool, false)
+    enable_reloader                     = optional(bool, false)
+    enable_tailscale_operator           = optional(bool, false)
+  })
+}

--- a/modules/argocd-registration/versions.tf
+++ b/modules/argocd-registration/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "ack" {
   value       = module.ack_capability
 }
 
+output "argocd_registration" {
+  description = "ArgoCD cluster registration outputs (file path and commit SHA)"
+  value       = module.argocd_registration
+}
+
 output "kubernetes_access_role_arns" {
   description = "Map of reusable Kubernetes access role names to their IAM role ARNs"
   value = {

--- a/variables.tf
+++ b/variables.tf
@@ -250,9 +250,52 @@ variable "enable_ack" {
 }
 
 variable "ack_iam_policy_arn" {
-  description = "IAM policy ARN to attach to the ACK capability role. Defaults to AdministratorAccess if not specified."
+  description = "IAM policy ARN to attach to the ACK capability role. When null (default), a purpose-built policy covering ACM, Route53, IAM CRUD, and EKS pod-identity actions is created automatically."
   type        = string
   default     = null
+}
+
+################################################################################
+# ArgoCD Dynamic Cluster Registration
+################################################################################
+
+variable "enable_argocd_registration" {
+  description = "Automatically register this cluster with the ArgoCD hub by committing a cluster Secret YAML to the GitOps repository via the GitHub provider."
+  type        = bool
+  default     = false
+}
+
+variable "argocd_registration" {
+  description = "ArgoCD cluster registration config. Required when enable_argocd_registration = true."
+  type = object({
+    github_repository      = string
+    github_branch          = optional(string, "main")
+    argocd_hub_environment = optional(string, "prod")
+    cluster_labels = object({
+      cluster_group  = string
+      environment    = string
+      team           = string
+      promotion_tier = string
+
+      enable_ack                          = optional(bool, false)
+      enable_adapter                      = optional(bool, false)
+      enable_aws_load_balancer_controller = optional(bool, false)
+      enable_cert_manager                 = optional(bool, false)
+      enable_datadog_operator             = optional(bool, false)
+      enable_downscaler                   = optional(bool, false)
+      enable_exporters                    = optional(bool, false)
+      enable_external_dns                 = optional(bool, false)
+      enable_external_dns_crossaccount    = optional(bool, false)
+      enable_external_secrets             = optional(bool, false)
+      enable_grafana                      = optional(bool, false)
+      enable_kargo                        = optional(bool, false)
+      enable_kube_prometheus_stack        = optional(bool, false)
+      enable_metrics_server               = optional(bool, false)
+      enable_reloader                     = optional(bool, false)
+      enable_tailscale_operator           = optional(bool, false)
+    })
+  })
+  default = null
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.11"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 6.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **New `modules/argocd-registration/`**: Terraform module that writes a per-cluster ArgoCD cluster Secret YAML to the GitOps repo (`fission-argocd`) via `github_repository_file`. When a new cluster is provisioned, a single `terraform apply` registers it with the ArgoCD hub — no manual `clusters.yaml` edits required.
- **`argocd-registration.tf`**: Root module wiring. Disabled by default (`enable_argocd_registration = false`). Activated by setting `enable_argocd_registration = true` and providing an `argocd_registration` block with GitHub repo, branch, hub environment, and cluster labels/feature flags.
- **Scoped ACK IAM policy**: Replaces the `AdministratorAccess` default on the ACK capability IAM role with a purpose-built policy covering only what the deployed ACK controllers need — ACM, Route53, IAM CRUD (for the IAM controller), and EKS pod-identity associations. `iam:PassRole` is locked to EKS principals only.
- **GitHub provider**: Added `integrations/github >= 6.0` to `required_providers`. Callers must configure the `github` provider with a token (`contents:write` on the GitOps repo).

## Companion PR

- fission-argocd: https://github.com/DND-IT/fission-argocd/pull/358 — splits `clusters.yaml` into a `clusters/` directory with auto-discovery kustomization so Terraform-written files are picked up without further changes.

## Test plan

- [ ] `terraform plan` with `enable_argocd_registration = false` (default) shows no changes to GitHub resources
- [ ] `terraform plan` with `enable_argocd_registration = true` and a valid `argocd_registration` block shows `github_repository_file.cluster_secret[0]` to be created at `configs/argocd/hub/prod/clusters/<name>.yaml`
- [ ] After `terraform apply`, verify the file appears in the `fission-argocd` repo with correct labels, endpoint, CA data, and spoke role ARN
- [ ] Verify ArgoCD hub picks up the new cluster Secret via `argocd cluster list`
- [ ] Second `terraform apply` is idempotent (no changes)
- [ ] `terraform plan` with `enable_ack = true` and `ack_iam_policy_arn = null` shows `aws_iam_policy.ack_controller[0]` being created (not `AdministratorAccess`)
- [ ] ACK IAM controller functions correctly after scoped policy is applied