### PR TITLE
ci: skip renovate PRs from example deploys

### DIFF
--- a/.github/workflows/examples-complete.yaml
+++ b/.github/workflows/examples-complete.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   example_complete_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')) || github.event_name == 'workflow_dispatch'
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-complete.yaml
+++ b/.github/workflows/examples-complete.yaml
@@ -9,8 +9,6 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:
-      - renovate/*
   workflow_dispatch:
 
 permissions:
@@ -24,7 +22,7 @@ concurrency:
 
 jobs:
   example_complete_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-datadog.yaml
+++ b/.github/workflows/examples-datadog.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   example_datadog_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')) || github.event_name == 'workflow_dispatch'
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-datadog.yaml
+++ b/.github/workflows/examples-datadog.yaml
@@ -10,8 +10,6 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:
-      - renovate/*
   workflow_dispatch:
 
 permissions:
@@ -25,7 +23,7 @@ concurrency:
 
 jobs:
   example_datadog_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-lacework.yaml
+++ b/.github/workflows/examples-lacework.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   example_lacework_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')) || github.event_name == 'workflow_dispatch'
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-lacework.yaml
+++ b/.github/workflows/examples-lacework.yaml
@@ -10,8 +10,6 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:
-      - renovate/*
   workflow_dispatch:
 
 permissions:
@@ -25,7 +23,7 @@ concurrency:
 
 jobs:
   example_lacework_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-network.yaml
+++ b/.github/workflows/examples-network.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   example_network_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
+    if: (github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')) || github.event_name == 'workflow_dispatch'
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/examples-network.yaml
+++ b/.github/workflows/examples-network.yaml
@@ -10,8 +10,6 @@ on:
       - synchronize
       - reopened
       - closed
-    branches-ignore:
-      - renovate/*
   workflow_dispatch:
 
 permissions:
@@ -25,7 +23,7 @@ concurrency:
 
 jobs:
   example_network_deploy:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
     uses: DND-IT/github-workflows/.github/workflows/tf-feature.yaml@v3
     with:
       environment: examples

--- a/.github/workflows/feature-destroy.yaml
+++ b/.github/workflows/feature-destroy.yaml
@@ -10,6 +10,10 @@ on:
         type: choice
         options:
           - tests/main
+          - examples/complete
+          - examples/datadog
+          - examples/lacework
+          - examples/network
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Motivation and Context

The intent on the `examples-*` workflows was always to exclude Renovate from deploying into the shared examples environment. In practice the filter never worked: for `pull_request` events, `on.pull_request.branches-ignore` matches the **base** branch, not the head, and Renovate PRs target `main`, so they were always allowed through.  

See: https://github.com/orgs/community/discussions/26795#discussioncomment-3253430

`feature-destroy.yaml` currently only offers `tests/main`, so there was no UI-driven way to destroy a stuck `examples/*` deploy without closing the offending PR.

  ## Breaking Changes

 None. These workflows only gate which PRs trigger the example deploy/destroy and which directories the manual destroy can target. No module inputs, outputs, or runtime behaviour change.

  ## How Has This Been Tested?

  - [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - [x] I have executed `pre-commit run -a` on my pull request