### PR TITLE
feat: adding efs driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | 6.3.0 |
 | <a name="module_argocd"></a> [argocd](#module\_argocd) | ./modules/argocd | n/a |
 | <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
+| <a name="module_aws_efs_csi_controller_pod_identity"></a> [aws\_efs\_csi\_controller\_pod\_identity](#module\_aws\_efs\_csi\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
+| <a name="module_aws_efs_csi_node_pod_identity"></a> [aws\_efs\_csi\_node\_pod\_identity](#module\_aws\_efs\_csi\_node\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_aws_gateway_controller_pod_identity"></a> [aws\_gateway\_controller\_pod\_identity](#module\_aws\_gateway\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |

--- a/addons.tf
+++ b/addons.tf
@@ -50,6 +50,22 @@ locals {
       #   service_account = "ebs-csi-controller-sa"
       # }]
     }
+
+    # Provides classic Amazon EFS and Amazon S3 Files storage (S3 Files needs
+    # driver v3.0.0+). IAM is supplied via the controller/node Pod Identity
+    # roles below; the node role has account-wide S3 read so applications only
+    # need to create a bucket and reference it.
+    aws-efs-csi-driver = {
+      most_recent = true
+      preserve    = false
+
+      # Increase timeout to allow Karpenter time to provision nodes
+      # Karpenter provisions nodes on-demand when pods are pending
+      timeouts = {
+        create = "20m"
+        update = "20m"
+      }
+    }
   }
 
   extra_cluster_addons = merge(local.cluster_addons, var.extra_cluster_addons)
@@ -112,6 +128,63 @@ module "aws_ebs_csi_pod_identity" {
       cluster_name    = module.eks.cluster_name
       namespace       = "kube-system"
       service_account = "ebs-csi-controller-sa"
+    }
+  }
+
+  tags = local.tags
+}
+
+# EFS CSI driver controller: classic EFS permissions plus the Amazon S3 Files
+module "aws_efs_csi_controller_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "2.8.1"
+
+  create = var.create_addon_pod_identity_roles
+
+  name            = "aws-efs-csi-controller-pod-identity-${local.id}"
+  use_name_prefix = false
+
+  attach_aws_efs_csi_policy = true
+
+  additional_policy_arns = {
+    AmazonS3FilesCSIDriverPolicy  = "arn:aws:iam::aws:policy/service-role/AmazonS3FilesCSIDriverPolicy"
+    AmazonS3FilesClientFullAccess = "arn:aws:iam::aws:policy/AmazonS3FilesClientFullAccess"
+  }
+
+  associations = {
+    controller = {
+      cluster_name    = module.eks.cluster_name
+      namespace       = "kube-system"
+      service_account = "efs-csi-controller-sa"
+    }
+  }
+
+  tags = local.tags
+}
+
+# EFS CSI driver node: account-level S3 Files client/mount permissions plus
+# account-wide S3 read so applications only need to create a bucket and
+# reference it.
+module "aws_efs_csi_node_pod_identity" {
+  source  = "terraform-aws-modules/eks-pod-identity/aws"
+  version = "2.8.1"
+
+  create = var.create_addon_pod_identity_roles
+
+  name            = "aws-efs-csi-node-pod-identity-${local.id}"
+  use_name_prefix = false
+
+  additional_policy_arns = {
+    AmazonS3FilesClientFullAccess = "arn:aws:iam::aws:policy/AmazonS3FilesClientFullAccess"
+    AmazonElasticFileSystemsUtils = "arn:aws:iam::aws:policy/AmazonElasticFileSystemsUtils"
+    AmazonS3ReadOnlyAccess        = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  }
+
+  associations = {
+    node = {
+      cluster_name    = module.eks.cluster_name
+      namespace       = "kube-system"
+      service_account = "efs-csi-node-sa"
     }
   }
 

--- a/addons.tf
+++ b/addons.tf
@@ -141,8 +141,9 @@ module "aws_efs_csi_controller_pod_identity" {
 
   create = var.create_addon_pod_identity_roles
 
-  name            = "aws-efs-csi-controller-pod-identity-${local.id}"
-  use_name_prefix = false
+  name                    = "aws-efs-csi-controller-pod-identity-${local.id}"
+  aws_efs_csi_policy_name = "aws-efs-csi-controller-pod-identity-${local.id}"
+  use_name_prefix         = false
 
   attach_aws_efs_csi_policy = true
 

--- a/addons.tf
+++ b/addons.tf
@@ -59,6 +59,12 @@ locals {
       most_recent = true
       preserve    = false
 
+      configuration_values = jsonencode({
+        controller = {
+          replicaCount = 1
+        }
+      })
+
       # Increase timeout to allow Karpenter time to provision nodes
       # Karpenter provisions nodes on-demand when pods are pending
       timeouts = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -188,6 +188,28 @@ module "k8s_platform" {
   # }
 }
 
+# Example: Using Amazon S3 Files with the EFS CSI driver
+#
+# The aws-efs-csi-driver add-on (driver v3.0.0+) is installed by the module and
+# provides classic Amazon EFS plus Amazon S3 Files storage. The driver's node
+# role is granted account-wide S3 read (AmazonS3ReadOnlyAccess), so an
+# application only needs to create a bucket and reference it - no per-bucket IAM.
+#
+# End-to-end steps for a consuming application (S3 Files has no Terraform
+# resource yet; the file system is created via the `aws s3files` API/CLI):
+#
+#   1. Create an S3 bucket (e.g. aws_s3_bucket.app).
+#
+#   2. Create the S3 file system and capture its id
+#
+#   3. Create mount targets in the cluster's subnets
+#
+#   4. Mount it with a StorageClass / PersistentVolume / PVC referencing the
+#      file system id. See the driver's S3 Files docs for the manifest schema:
+#        https://docs.aws.amazon.com/eks/latest/userguide/s3files-csi.html
+#
+
+
 data "aws_secretsmanager_secret_version" "cloudflare" {
   secret_id = "dai/cloudflare/tamedia/apiToken"
 }


### PR DESCRIPTION
## Description
Adds the aws-efs-csi-driver EKS add-on so the platform can provision classic Amazon EFS storage and the new Amazon S3 Files storage (requires driver v3.0.0+). IAM is supplied via two Pod Identity roles:

- controller (efs-csi-controller-sa): classic EFS CSI permissions + AmazonS3FilesCSIDriverPolicy + AmazonS3FilesClientFullAccess
- node (efs-csi-node-sa): AmazonS3FilesClientFullAccess + AmazonElasticFileSystemsUtils + AmazonS3ReadOnlyAccess

The node role gets account-wide S3 read so consuming applications only need to create a bucket and reference it — no per-bucket IAM wiring required.

### Motivation and Context

Amazon S3 Files (released April 2026) is delivered through the EFS CSI driver, not a standalone driver. This lets applications mount S3 buckets as file systems with full filesystem semantics. 

### Breaking Changes

None. The add-on is additive and the Pod Identity roles follow the existing create_addon_pod_identity_roles gate (default true), consistent with the other add-ons.

### How Has This Been Tested?

- [x] I have updated at least one of the examples/* to demonstrate and validate my change(s)
  - examples/complete documents end-to-end S3 Files usage (bucket → aws s3files create-file-system → mount targets → manifest).
- [x] I have tested and validated these changes using one or more of the provided examples/* projects
  - Not deployed: terraform validate passes, but the AmazonS3Files* / AmazonElasticFileSystemsUtils managed-policy ARNs are only verified at plan/apply.
- [x] I have executed pre-commit run -a on my pull request

