### PR TITLE
feat!: bump default Kubernetes version to 1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
-
-### ⚠ BREAKING CHANGES
-
-* **Bump default Kubernetes version to 1.35.** Per the module's versioning policy, a Kubernetes minor upgrade is released as a MAJOR version. Clusters on 1.34 are upgraded in place when applying; the upgrade cannot be skipped or rolled back, so review the notes below first. Pin `kubernetes_version = "1.34"` to defer.
-
-  Notable Kubernetes 1.35 changes ([EKS 1.35 support](https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-eks-distro-kubernetes-version-1-35/)):
-  * **cgroup v1 is deprecated** — the kubelet refuses to start by default on cgroup v1 nodes; ensure node AMIs use cgroup v2.
-  * **Last release to support containerd 1.x** — migrate nodes to containerd 2.0+ before the next Kubernetes upgrade.
-  * In-Place Pod Resource Updates (adjust CPU/memory without restarting Pods).
-  * `PreferSameNode` traffic distribution for lower-latency, node-local routing.
-  * Node topology labels exposed via the Downward API.
-  * Image Volumes for mounting OCI artifacts (e.g. AI models).
-  * EKS 1.35 adds Windows Server 2025 support.
-
 ## [6.14.0](https://github.com/tx-pts-dai/terraform-aws-kubernetes-platform/compare/v6.13.0...v6.14.0) (2026-06-29)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ⚠ BREAKING CHANGES
+
+* **Bump default Kubernetes version to 1.35.** Per the module's versioning policy, a Kubernetes minor upgrade is released as a MAJOR version. Clusters on 1.34 are upgraded in place when applying; the upgrade cannot be skipped or rolled back, so review the notes below first. Pin `kubernetes_version = "1.34"` to defer.
+
+  Notable Kubernetes 1.35 changes ([EKS 1.35 support](https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-eks-distro-kubernetes-version-1-35/)):
+  * **cgroup v1 is deprecated** — the kubelet refuses to start by default on cgroup v1 nodes; ensure node AMIs use cgroup v2.
+  * **Last release to support containerd 1.x** — migrate nodes to containerd 2.0+ before the next Kubernetes upgrade.
+  * In-Place Pod Resource Updates (adjust CPU/memory without restarting Pods).
+  * `PreferSameNode` traffic distribution for lower-latency, node-local routing.
+  * Node topology labels exposed via the Downward API.
+  * Image Volumes for mounting OCI artifacts (e.g. AI models).
+  * EKS 1.35 adds Windows Server 2025 support.
+
 ## [6.14.0](https://github.com/tx-pts-dai/terraform-aws-kubernetes-platform/compare/v6.13.0...v6.14.0) (2026-06-29)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ module "k8s_platform" {
 
 **Important**: Do not skip Kubernetes minor versions during upgrades. For example, upgrade from 1.32 → 1.33 → 1.34, not directly from 1.32 → 1.34.
 
+### Notes for 1.35
+
+When upgrading to the current default (`1.35`), be aware of the following ([EKS 1.35 support](https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-eks-distro-kubernetes-version-1-35/)):
+
+- **cgroup v1 is deprecated** — the kubelet refuses to start by default on cgroup v1 nodes; ensure node AMIs use cgroup v2.
+- **Last release to support containerd 1.x** — migrate nodes to containerd 2.0+ before the next Kubernetes upgrade.
+
 ## Versioning and Releases
 
 This module follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). Releases are automated with [semantic-release](https://github.com/semantic-release/semantic-release) and derived from [Conventional Commits](https://www.conventionalcommits.org/) on `main`:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To upgrade your cluster to a new Kubernetes version:
 module "k8s_platform" {
   source = "tx-pts-dai/kubernetes-platform/aws"
 
-  kubernetes_version = "1.34"
+  kubernetes_version = "1.35"
 
   # ... other configuration
 }
@@ -67,6 +67,27 @@ module "k8s_platform" {
 
 **Important**: Do not skip Kubernetes minor versions during upgrades. For example, upgrade from 1.32 → 1.33 → 1.34, not directly from 1.32 → 1.34.
 
+## Versioning and Releases
+
+This module follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). Releases are automated with [semantic-release](https://github.com/semantic-release/semantic-release) and derived from [Conventional Commits](https://www.conventionalcommits.org/) on `main`:
+
+| Commit type | Example | Version bump |
+| ----------- | ------- | ------------ |
+| `fix:` | `fix: correct karpenter subnet tag` | PATCH (`x.y.Z`) |
+| `feat:` | `feat: add efs driver` | MINOR (`x.Y.0`) |
+| `feat!:` / `fix!:` or a `BREAKING CHANGE:` footer | `feat!: drop support for k8s 1.32` | MAJOR (`X.0.0`) |
+
+Guidelines for choosing the bump:
+
+- **PATCH** — backwards-compatible bug fixes that do not change the module interface or default behaviour.
+- **MINOR** — backwards-compatible new features (new variables, new optional resources) where existing configurations keep working unchanged.
+- **MAJOR** — any backwards-incompatible change: removed or renamed variables/outputs, changed defaults that alter live infrastructure, or behaviour that requires consumers to take action before upgrading.
+
+### Kubernetes minor version updates require a MAJOR release
+
+Bumping the default `kubernetes_version` by a minor version (e.g. `1.33` → `1.34`) **must be released as a MAJOR version** of this module. A Kubernetes minor upgrade is a backwards-incompatible change for consumers: it advances the control plane, may deprecate or remove APIs, and cannot be skipped or rolled back, so it requires deliberate action before upgrading. Mark such changes as breaking (use `feat!:` or a `BREAKING CHANGE:` footer) so semantic-release produces a MAJOR bump.
+
+Always [pin the module to a specific version](#usage) so that MAJOR releases never reach your infrastructure unintentionally.
 
 ## Explanation and description of interesting use-cases
 
@@ -214,7 +235,7 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="input_karpenter_resources_helm_set"></a> [karpenter\_resources\_helm\_set](#input\_karpenter\_resources\_helm\_set) | List of Karpenter Resources Helm set values | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>    type  = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_karpenter_resources_helm_values"></a> [karpenter\_resources\_helm\_values](#input\_karpenter\_resources\_helm\_values) | List of Karpenter Resources Helm values | `list(string)` | `[]` | no |
 | <a name="input_kubernetes_access_roles"></a> [kubernetes\_access\_roles](#input\_kubernetes\_access\_roles) | Map of reusable IAM roles that can be assumed by multiple principals.<br/>Creates standard roles that grant different levels of Kubernetes access.<br/><br/>Supported predefined access\_level values:<br/>- "view"         -> AmazonEKSViewPolicy (read-only)<br/>- "edit"         -> AmazonEKSEditPolicy (create/update resources)<br/>- "admin"        -> AmazonEKSClusterAdminPolicy (full admin)<br/>- "custom"       -> Use custom\_policy\_arns (list of policy ARNs)<br/><br/>Example:<br/>{<br/>  "readonly" = {<br/>    controller\_iam\_role\_arns = [<br/>      "arn:aws:iam::123456789012:role/backstage-prod",<br/>      "arn:aws:iam::123456789012:role/ai-agent"<br/>    ]<br/>    access\_level = "view"           # Predefined: view, edit, admin, or custom<br/>    scope        = "cluster"        # "cluster" or "namespace"<br/>    namespaces   = []               # required if scope = "namespace"<br/>  }<br/>  "developer" = {<br/>    controller\_iam\_role\_arns = ["arn:aws:iam::123456789012:role/dev-team"]<br/>    access\_level = "edit"<br/>    scope        = "namespace"<br/>    namespaces   = ["development", "staging"]<br/>  }<br/>  "ops-admin" = {<br/>    controller\_iam\_role\_arns = ["arn:aws:iam::123456789012:role/ops-team"]<br/>    access\_level = "admin"<br/>    scope        = "cluster"<br/>  }<br/>  "custom-access" = {<br/>    controller\_iam\_role\_arns = ["arn:aws:iam::123456789012:role/special-service"]<br/>    access\_level = "custom"<br/>    custom\_policy\_arns = [<br/>      "arn:aws:eks::aws:cluster-access-policy/MyCustomPolicy"<br/>    ]<br/>    scope = "cluster"<br/>  }<br/>}<br/><br/>This creates:<br/>- {cluster}-k8s-readonly (view access)<br/>- {cluster}-k8s-developer (edit access on dev/staging namespaces)<br/>- {cluster}-k8s-ops-admin (full admin access)<br/>- {cluster}-k8s-custom-access (custom policies) | <pre>map(object({<br/>    controller_iam_role_arns = list(string)<br/>    access_level             = string # "view", "edit", "admin", or "custom"<br/>    scope                    = string # "cluster" or "namespace"<br/>    namespaces               = optional(list(string), [])<br/>    custom_policy_arns       = optional(list(string), [])<br/>    external_id              = optional(string)<br/>  }))</pre> | `{}` | no |
-| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the EKS cluster (e.g., "1.34") | `string` | `"1.34"` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the EKS cluster (e.g., "1.35") | `string` | `"1.35"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the platform, a timestamp will be appended to this name to make the stack\_name. If not provided, the name of the directory will be used. | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Default tags to apply to all resources | `map(string)` | `{}` | no |

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -446,7 +446,7 @@ module "karpenter" {
 resource "helm_release" "karpenter_crd" {
   name             = "karpenter-crd"
   chart            = "karpenter-crd"
-  version          = "1.10.0"
+  version          = "1.13.0" # renovate: datasource=github-releases depName=aws/karpenter-provider-aws
   repository       = "oci://public.ecr.aws/karpenter"
   description      = "Karpenter CRDs"
   namespace        = local.karpenter.namespace
@@ -456,7 +456,7 @@ resource "helm_release" "karpenter_crd" {
 resource "helm_release" "karpenter_release" {
   name             = "karpenter"
   chart            = "karpenter"
-  version          = "1.10.0"
+  version          = "1.13.0" # renovate: datasource=github-releases depName=aws/karpenter-provider-aws
   repository       = "oci://public.ecr.aws/karpenter"
   namespace        = local.karpenter.namespace
   create_namespace = true
@@ -479,7 +479,7 @@ resource "helm_release" "karpenter_release" {
       clusterEndpoint: ${module.eks.cluster_endpoint}
       interruptionQueue: ${module.karpenter.queue_name}
       featureGates:
-        spotToSpotConsolidation: true
+        spotToSpotConsolidation: false
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: ${module.karpenter_irsa.arn}
@@ -515,10 +515,14 @@ resource "helm_release" "karpenter_resources" {
     nodePools:
       default:
         enabled: true
+        disruption:
+          consolidateAfter: 1m
 
     ec2NodeClasses:
       default:
         enabled: true
+        amiSelectorTerms:
+          - alias: bottlerocket@v1.62.1 # renovate: datasource=github-releases depName=bottlerocket-os/bottlerocket
     EOT
   ], var.karpenter_resources_helm_values)
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,18 @@
   ],
   "schedule": [
     "after 9am on Monday"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the Bottlerocket AMI alias in the Karpenter EC2NodeClass via GitHub releases",
+      "fileMatch": [
+        "^karpenter\\.tf$"
+      ],
+      "matchStrings": [
+        "alias: bottlerocket@(?<currentValue>\\S+)\\s*#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+packageName=(?<packageName>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+registryUrl=(?<registryUrl>\\S+))?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{/if}}"
+    }
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,9 +39,9 @@ variable "vpc" {
 }
 
 variable "kubernetes_version" {
-  description = "Kubernetes version for the EKS cluster (e.g., \"1.34\")"
+  description = "Kubernetes version for the EKS cluster (e.g., \"1.35\")"
   type        = string
-  default     = "1.34"
+  default     = "1.35"
 }
 
 variable "eks" {


### PR DESCRIPTION
## What

- Bump default `kubernetes_version` from **1.34 → 1.35** (`variables.tf`, README usage + docs table).
- Document the module **versioning policy** (SemVer via semantic-release / Conventional Commits) in the README, including that a **Kubernetes minor bump is released as a MAJOR** module version; add an `Unreleased` CHANGELOG entry summarizing the relevant Kubernetes 1.35 changes.
- Upgrade Karpenter Helm chart + CRDs **1.10.0 → 1.13.0**.
- Pin the EC2NodeClass AMI alias to **`bottlerocket@v1.62.1`** instead of tracking `latest`, for reproducible node images.
- Tune the default NodePool/EC2NodeClass: `disruption.consolidateAfter: 1m` and `featureGates.spotToSpotConsolidation: false`.
- Add Renovate tracking: inline `# renovate: datasource=github-releases` markers on the Karpenter chart versions and the Bottlerocket alias, plus a custom regex manager in `renovate.json` for the AMI alias.

## Why

A Kubernetes minor upgrade is backwards-incompatible for consumers (control-plane advance, can't be skipped or rolled back), so per the documented policy it warrants a MAJOR release. The Karpenter upgrade and AMI pin keep node provisioning current and reproducible, with Renovate wiring so both stay maintained.

## ⚠ Breaking changes / upgrade notes

- **Kubernetes 1.35**: clusters on 1.34 are upgraded **in place** on apply; cannot be skipped or rolled back. Pin `kubernetes_version = "1.34"` to defer.
  - **cgroup v1 is deprecated** — kubelet refuses to start by default on cgroup v1 nodes; ensure node AMIs use cgroup v2.
  - **1.35 is the last release supporting containerd 1.x** — migrate nodes to containerd 2.0+ before the next upgrade.
  - EKS has supported 1.35 since 2026-01-28.
- **Pinned Bottlerocket AMI** (`v1.62.1`): nodes roll to this image on apply rather than whatever `latest` resolved to. Expect node replacement.
- **`spotToSpotConsolidation` disabled**: Karpenter no longer consolidates spot→spot, changing disruption behaviour for spot-heavy clusters.
- Review the [Karpenter 1.10 → 1.13 release notes](https://github.com/aws/karpenter-provider-aws/releases) for any CRD/API changes.

## Notes

- semantic-release will cut a **MAJOR** release for this PR (the Kubernetes commit carries a `BREAKING CHANGE:` footer).
- The `terraform_validate` pre-commit hook fails locally due to a stale `.terraform` module cache (registry `terraform.io` → `opentofu.org`); unrelated to these changes — a fresh `init` (as in CI) resolves it.