### PR TITLE
fix: align karpenter controller IAM policy with upstream module

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ as described in the `.pre-commit-config.yaml` file
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_ack_capability"></a> [ack\_capability](#module\_ack\_capability) | terraform-aws-modules/eks/aws//modules/capability | 21.15.1 |
+| <a name="module_ack_capability"></a> [ack\_capability](#module\_ack\_capability) | terraform-aws-modules/eks/aws//modules/capability | 21.24.0 |
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | 6.3.0 |
 | <a name="module_argocd"></a> [argocd](#module\_argocd) | ./modules/argocd | n/a |
 | <a name="module_aws_ebs_csi_pod_identity"></a> [aws\_ebs\_csi\_pod\_identity](#module\_aws\_ebs\_csi\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
@@ -169,11 +169,11 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="module_aws_lb_controller_pod_identity"></a> [aws\_lb\_controller\_pod\_identity](#module\_aws\_lb\_controller\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_aws_vpc_cni_pod_identity"></a> [aws\_vpc\_cni\_pod\_identity](#module\_aws\_vpc\_cni\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | 6.6.1 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.15.1 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 21.24.0 |
 | <a name="module_eks_addons"></a> [eks\_addons](#module\_eks\_addons) | ./modules/eks-addons | n/a |
 | <a name="module_external_dns_pod_identity"></a> [external\_dns\_pod\_identity](#module\_external\_dns\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
 | <a name="module_external_secrets_pod_identity"></a> [external\_secrets\_pod\_identity](#module\_external\_secrets\_pod\_identity) | terraform-aws-modules/eks-pod-identity/aws | 2.8.1 |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.15.1 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | terraform-aws-modules/eks/aws//modules/karpenter | 21.24.0 |
 | <a name="module_karpenter_irsa"></a> [karpenter\_irsa](#module\_karpenter\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts | 6.6.1 |
 | <a name="module_karpenter_security_group"></a> [karpenter\_security\_group](#module\_karpenter\_security\_group) | ./modules/security-group | n/a |
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | ./modules/ssm | n/a |
@@ -189,9 +189,9 @@ as described in the `.pre-commit-config.yaml` file
 | [aws_eks_access_policy_association.k8s_access_predefined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_policy_association) | resource |
 | [aws_iam_policy.ecr_passthrough](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.k8s_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.k8s_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.karpenter_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_route_table_association.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_security_group_rule.eks_control_plane_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "arn:aws:ec2:${local.region}:*:security-group/*",
       "arn:aws:ec2:${local.region}:*:subnet/*",
       "arn:aws:ec2:${local.region}:*:capacity-reservation/*",
+      "arn:aws:ec2:${local.region}:*:placement-group/*",
     ]
 
     actions = [
@@ -200,7 +201,9 @@ data "aws_iam_policy_document" "karpenter_controller" {
       "ec2:DescribeLaunchTemplates",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSpotPriceHistory",
-      "ec2:DescribeSubnets"
+      "ec2:DescribeSubnets",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribePlacementGroups"
     ]
 
     condition {
@@ -220,6 +223,18 @@ data "aws_iam_policy_document" "karpenter_controller" {
     sid       = "AllowPricingReadActions"
     resources = ["*"]
     actions   = ["pricing:GetProducts"]
+  }
+
+  statement {
+    sid       = "AllowZonalShiftReadActions"
+    resources = ["*"]
+    actions   = ["arc-zonal-shift:GetManagedResource"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "arc-zonal-shift:ResourceIdentifier"
+      values   = ["arn:aws:eks:${local.region}:${local.account_id}:cluster/${module.eks.cluster_name}"]
+    }
   }
 
   statement {

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -233,7 +233,7 @@ data "aws_iam_policy_document" "karpenter_controller" {
     condition {
       test     = "StringEquals"
       variable = "arc-zonal-shift:ResourceIdentifier"
-      values   = ["arn:aws:eks:${local.region}:${local.account_id}:cluster/${module.eks.cluster_name}"]
+      values   = [module.eks.cluster_arn]
     }
   }
 

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -384,8 +384,10 @@ data "aws_iam_policy_document" "karpenter_controller" {
   }
 }
 
-resource "aws_iam_policy" "karpenter_controller" {
+# Inline policy to avoid the 6144 char managed-policy size limit
+resource "aws_iam_role_policy" "karpenter_controller" {
   name   = "karpenter-controller-${local.id}"
+  role   = module.karpenter_irsa.name
   policy = data.aws_iam_policy_document.karpenter_controller.json
 }
 
@@ -398,9 +400,6 @@ module "karpenter_irsa" {
   use_name_prefix = false
 
   create_policy = false
-  policies = {
-    controller = aws_iam_policy.karpenter_controller.arn
-  }
 
   oidc_providers = {
     main = {

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -23,7 +23,7 @@ See the [network example](../../example/network) how to use it and how to retrie
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_ssm"></a> [ssm](#module\_ssm) | ./../ssm | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.6.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 6.6.1 |
 
 ## Resources
 


### PR DESCRIPTION
## What

The vendored Karpenter controller IAM policy (`data.aws_iam_policy_document.karpenter_controller` in `karpenter.tf`) had drifted behind the upstream [`terraform-aws-modules/eks//modules/karpenter/policy.tf`](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/karpenter/policy.tf). This adds the missing permissions:

- **`AllowZonalShiftReadActions`** — new statement granting `arc-zonal-shift:GetManagedResource` (scoped to `module.eks.cluster_arn`) for Karpenter's ARC zonal-shift awareness.
- **`AllowRegionalReadActions`** — add `ec2:DescribeInstanceStatus` and `ec2:DescribePlacementGroups`.
- **`AllowScopedEC2InstanceAccessActions`** — add `placement-group/*` to the resource scope so `RunInstances`/`CreateFleet` can target placement groups referenced by an EC2NodeClass.

## Managed -> inline policy

The added statements pushed the document past the **6144-character managed-policy quota** (`LimitExceeded: Cannot exceed quota for PolicySize: 6144`, not adjustable). The controller policy is now attached as an **inline `aws_iam_role_policy`** on the IRSA role (aggregate limit 10240 chars) instead of a standalone managed policy, and the managed-policy attachment was removed.

### Apply note
On apply, the managed policy `aws_iam_policy.karpenter-controller-<id>` is detached/deleted and replaced by an inline policy of the same name on the existing role. Same permissions, same role — no service-account or trust changes.

## Why

These permissions exist in the upstream module but were absent from our vendored copy. Without them, ARC zonal shift integration and placement-group-based node classes fail, and newer Karpenter (1.13.0) read paths are incomplete. No behaviour change for clusters not using those features — the statements are additive.

## Testing

- `tofu fmt` clean.
- Local `terraform_validate` pre-commit hook is unrelated-failing due to a stale module cache (`terraform.io` -> `opentofu.org`); CI runs a fresh init.